### PR TITLE
fix: keep manifest warnings non-fatal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.codex
+.claude
+.grok
+target
+**/*.rs.bk
+.specify/cache
+.specify/tmp
+*.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 Auto-generated from all feature plans. Last updated: 2025-10-09
 
 ## Active Technologies
-- Rust 1.82.0 (MSRV aligned with Gemini CLI extension tooling) + reqwest + tokio (HTTP), serde/serde_json (manifests), directories (config paths), thiserror/anyhow (errors), indicatif (UX); dev: assert_cmd, insta, wiremock (001-build-a-gemini)
+- Rust 1.82.0 with reqwest + tokio (HTTP), serde/serde_json (manifests), directories (config paths), thiserror/anyhow (errors), indicatif (UX); dev stack: assert_cmd, insta, wiremock, humantime, axum (001-build-a-gemini)
+- Per-source JSON cache under `$GEMINI_CONFIG/extensions/marketplace/` with TTL metadata and manual refresh (001-build-a-gemini)
 
 ## Project Structure
 ```
@@ -12,13 +13,14 @@ tests/
 ```
 
 ## Commands
-cargo test [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLOGIES] cargo clippy
+- `cargo test` (run locally once rustup can create temp files)
+- `cargo clippy --all-targets -- -D warnings`
 
 ## Code Style
 Rust 1.82.0 (MSRV aligned with Gemini CLI extension tooling): Follow standard conventions
 
 ## Recent Changes
-- 001-build-a-gemini: Added Rust 1.82.0 (MSRV aligned with Gemini CLI extension tooling) + reqwest + tokio (HTTP), serde/serde_json (manifests), directories (config paths), thiserror/anyhow (errors), indicatif (UX); dev: assert_cmd, insta, wiremock
+- 001-build-a-gemini: Locked MSRV to 1.82.0 (ICU/idna dependency requirement) and documented the test stack (assert_cmd, wiremock, humantime, axum)
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 Auto-generated from all feature plans. Last updated: 2025-10-09
 
 ## Active Technologies
-- Rust 1.82.0 with reqwest + tokio (HTTP), serde/serde_json (manifests), directories (config paths), thiserror/anyhow (errors), indicatif (UX); dev stack: assert_cmd, insta, wiremock, humantime, axum (001-build-a-gemini)
+- Rust 1.82.0 with reqwest + tokio (HTTP), serde/serde_json (manifests), directories (config paths), thiserror/anyhow (errors), indicatif (UX); dev stack: assert_cmd, insta, predicates, humantime, axum for test servers (001-build-a-gemini)
 - Per-source JSON cache under `$GEMINI_CONFIG/extensions/marketplace/` with TTL metadata and manual refresh (001-build-a-gemini)
 
 ## Project Structure
@@ -20,7 +20,7 @@ tests/
 Rust 1.82.0 (MSRV aligned with Gemini CLI extension tooling): Follow standard conventions
 
 ## Recent Changes
-- 001-build-a-gemini: Locked MSRV to 1.82.0 (ICU/idna dependency requirement) and documented the test stack (assert_cmd, wiremock, humantime, axum)
+- 001-build-a-gemini: Locked MSRV to 1.82.0 (ICU/idna dependency requirement) and documented the test stack (assert_cmd, predicates, humantime, axum)
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,16 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +127,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -231,6 +227,15 @@ name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -354,6 +359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,28 +377,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "deadpool"
-version = "0.12.3"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "deadpool-runtime",
- "lazy_static",
- "num_cpus",
- "tokio",
+ "generic-array",
+ "typenum",
 ]
-
-[[package]]
-name = "deadpool-runtime"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "directories"
@@ -431,10 +447,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
+name = "errno"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -453,6 +479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,28 +503,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -497,17 +516,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -544,7 +552,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -569,14 +576,26 @@ dependencies = [
  "humantime-serde",
  "indicatif",
  "insta",
+ "predicates",
  "reqwest",
  "semver",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "url",
- "wiremock",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -613,41 +632,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
-name = "h2"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -721,7 +709,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -883,16 +870,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
 name = "indicatif"
 version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,12 +944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +958,12 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1055,13 +1032,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
+name = "normalize-line-endings"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
- "hermit-abi",
- "libc",
+ "autocfg",
 ]
 
 [[package]]
@@ -1170,7 +1152,10 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]
@@ -1415,6 +1400,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,6 +1470,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -1537,6 +1539,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1635,6 +1648,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1835,6 +1861,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,6 +1907,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -2259,29 +2297,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "wiremock"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
-dependencies = [
- "assert-json-diff",
- "base64",
- "deadpool",
- "futures",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "tokio",
- "url",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,11 @@ humantime = "2.1"
 humantime-serde = "1.1"
 clap = { version = "4.5", features = ["derive"] }
 axum = { version = "0.7", features = ["macros", "json"] }
+sha2 = "0.10"
 
 [dev-dependencies]
 assert_cmd = "2.0"
 insta = { version = "1.39", features = ["yaml"] }
 wiremock = "0.6"
+predicates = "3.0"
+tempfile = "3.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.41", features = ["full"] }
-semver = "1.0"
+semver = { version = "1.0", features = ["serde"] }
 url = "2.5"
 humantime = "2.1"
 humantime-serde = "1.1"
@@ -31,6 +31,5 @@ sha2 = "0.10"
 [dev-dependencies]
 assert_cmd = "2.0"
 insta = { version = "1.39", features = ["yaml"] }
-wiremock = "0.6"
 predicates = "3.0"
 tempfile = "3.10"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Gemini Marketplace Extension
 
-A Rust-based Gemini CLI extension that surfaces third-party extensions from multiple sources, with caching, search, and source management.
+This repo holds a Gemini CLI extension written in Rust that discovers third-party extensions from GitHub-based catalogs. This project is built in Rust because the Gemini CLI already ships with a Rust toolchain. Additionally, async HTTP + filesystem work both benefit from Rust’s safety guarantees.
 
-## Project Layout
+## Project Layout (Why it looks like this)
+
+The source tree mirrors how Gemini CLI extensions load crates: a single binary entrypoint under `src/bin/` plus feature modules under `src/marketplace/`. Tests are split so unit tests stay fast and integration tests can spin up wiremock servers.
 
 ```
 .
@@ -37,15 +39,11 @@ cargo build
 cargo run -- list --help
 ```
 
+## Testing Strategy
+
+The plan leans on `wiremock` for HTTP playback and `assert_cmd` for end-to-end CLI assertions. The `GEMINI_MARKETPLACE_HOME` environment override is added so tests can isolate cache directories without touching the actual Gemini config. Run `cargo test` once rustup can write temp files; the sandbox blocks it here.
+
 ## Toolchain
 
-- Rust 1.82.0
+- Rust 1.82.0 (matches upstream ICU/idna requirements)
 - `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test`
-
-## Publishing with GitHub CLI
-
-```
-gh auth login
-gh repo create <org-or-user>/gemini-marketplace --private --source . --remote origin
-git push -u origin main
-```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo holds a Gemini CLI extension written in Rust that discovers third-part
 
 ## Project Layout (Why it looks like this)
 
-The source tree mirrors how Gemini CLI extensions load crates: a single binary entrypoint under `src/bin/` plus feature modules under `src/marketplace/`. Tests are split so unit tests stay fast and integration tests can spin up wiremock servers.
+The source tree mirrors how Gemini CLI extensions load crates: a single binary entrypoint under `src/bin/` plus feature modules under `src/marketplace/`. Tests are split so unit tests stay fast and integration tests can spin up lightweight axum servers instead of hitting GitHub.
 
 ```
 .
@@ -41,7 +41,7 @@ cargo run -- list --help
 
 ## Testing Strategy
 
-The plan leans on `wiremock` for HTTP playback and `assert_cmd` for end-to-end CLI assertions. The `GEMINI_MARKETPLACE_HOME` environment override is added so tests can isolate cache directories without touching the actual Gemini config. Run `cargo test` once rustup can write temp files; the sandbox blocks it here.
+The plan leans on axum-backed harnesses for HTTP playback and `assert_cmd` for end-to-end CLI assertions. The `GEMINI_MARKETPLACE_HOME` environment override isolates test cache directories and does not rely upon modifying the Gemini config. Run `cargo test` once rustup can write temp files; the sandbox blocks it here.
 
 ## Toolchain
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,6 +1,0 @@
-warns = [
-  "clippy::pedantic",
-  "clippy::nursery"
-]
-
-allow-macro-by-default = false

--- a/specs/001-build-a-gemini/checklists/api-data.md
+++ b/specs/001-build-a-gemini/checklists/api-data.md
@@ -1,0 +1,59 @@
+# API & Data Requirements Checklist: Gemini CLI Extension Marketplace
+
+**Purpose**: Author self-check focusing on manifest ingestion, caching, rate limits, and REST/CLI data contracts
+**Created**: 2025-10-09
+**Feature**: specs/001-build-a-gemini/spec.md
+
+## Requirement Completeness
+
+- [ ] CHK001 Are the required manifest fields (name, version, author, repository, categories, compatibility) fully enumerated in requirements? [Completeness, Spec §Functional Requirements FR-013a]
+- [ ] CHK002 Do requirements specify all data points returned by the list endpoint/CLI (display name, namespace, version, install status, source)? [Completeness, Spec §Functional Requirements FR-002]
+- [ ] CHK003 Is the default curated source (`https://github.com/athola/gemini-marketplace`) documented along with enable/disable behavior? [Completeness, Spec §Functional Requirements FR-005–FR-005a]
+- [ ] CHK004 Are cache metadata expectations (TTL, manual refresh, storage path) fully described? [Completeness, Spec §Functional Requirements FR-010–FR-011]
+
+## Requirement Clarity
+
+- [ ] CHK005 Is the process for slug generation and namespace format unambiguous? [Clarity, Spec §Functional Requirements FR-002a]
+- [ ] CHK006 Are error responses for manifest validation failures clearly defined (fields, messaging)? [Clarity, Spec §Clarifications 2025-10-09, Spec §Edge Cases]
+- [ ] CHK007 Are rate-limit countdown behaviors and exposed fields (reset time, remaining) explicitly stated? [Clarity, Spec §Functional Requirements FR-012a]
+- [ ] CHK008 Is the distinction between registry detection versus filesystem fallback for install status spelled out? [Clarity, Spec §Functional Requirements FR-014]
+
+## Requirement Consistency
+
+- [ ] CHK009 Do the CLI display requirements align with REST schemas in the OpenAPI contract (field names/structures)? [Consistency, Spec §Functional Requirements FR-001–FR-004, Contracts/marketplace-openapi.yaml]
+- [ ] CHK010 Are cache invalidation rules consistent between Functional Requirements and Edge Case handling? [Consistency, Spec §Functional Requirements FR-010–FR-011, Spec §Edge Cases]
+- [ ] CHK011 Is credential-helper reliance described consistently across Clarifications, Functional Requirements, and assumptions? [Consistency, Spec §Clarifications 2025-10-09, Spec §Functional Requirements FR-013c, Spec §Dependencies]
+
+## Acceptance Criteria Quality
+
+- [ ] CHK012 Can the acceptance criteria for User Story 1 be objectively evaluated for data fields and grouping behavior? [Acceptance Criteria, Spec §User Story 1]
+- [ ] CHK013 Do User Story 2 criteria cover every data element promised in the detail view (README excerpt, compatibility, install instructions)? [Acceptance Criteria, Spec §User Story 2]
+- [ ] CHK014 Are success metrics SC-001 through SC-007 traceable to data/API requirements (e.g., cache latency ties to FR-010)? [Acceptance Criteria, Spec §Success Criteria]
+
+## Scenario Coverage
+
+- [ ] CHK015 Are offline cache browse scenarios documented, including when remote data is unavailable? [Coverage, Spec §Assumptions, Spec §Functional Requirements FR-010]
+- [ ] CHK016 Are private-source authentication flows and failure messaging specified? [Coverage, Spec §Clarifications 2025-10-09, Spec §Functional Requirements FR-013c]
+- [ ] CHK017 Do requirements address how deleted or relocated repositories affect listings and caching? [Coverage, Spec §Edge Cases]
+
+## Edge Case Coverage
+
+- [ ] CHK018 Are malformed or missing `gemini-extension.json` manifests handled consistently across list and detail views? [Edge Case, Spec §Clarifications 2025-10-09, Spec §Edge Cases]
+- [ ] CHK019 Is behavior defined when manifests lack optional fields (tags, documentation, compatibility)? [Edge Case, Spec §Functional Requirements FR-013a]
+
+## Non-Functional Requirements
+
+- [ ] CHK020 Are observability outputs (dual-mode logs, structured metrics) tied to specific events (cache hit/miss, rate-limit queue)? [Non-Functional, Spec §Clarifications 2025-10-09, Spec §Non-Functional Requirements NFR-001]
+- [ ] CHK021 Are performance targets for cached listing render speed mapped to measurable data operations? [Non-Functional, Spec §Success Criteria SC-003]
+- [ ] CHK022 Are security expectations around storing no credentials and relying on helpers described for all relevant actions? [Non-Functional, Spec §Functional Requirements FR-013c]
+
+## Dependencies & Assumptions
+
+- [ ] CHK023 Are external GitHub API constraints and metadata format assumptions captured, including rate-limit policies? [Dependencies, Spec §Dependencies]
+- [ ] CHK024 Does the spec document dependencies on Gemini CLI extension registry/file layout with fallback assumptions? [Dependencies, Spec §Dependencies, Spec §Functional Requirements FR-014]
+
+## Ambiguities & Conflicts
+
+- [ ] CHK025 Are there any conflicting statements about enabling/disabling the default source versus user-added sources? [Ambiguity, Spec §Functional Requirements FR-005–FR-007]
+- [ ] CHK026 Is terminology for “source”, “catalog”, and “marketplace” consistent throughout the spec and clarifications? [Consistency, Spec §Clarifications 2025-10-09, Spec §Functional Requirements]
+- [ ] CHK027 Are data export/import expectations (e.g., manifest schema versioning) clearly addressed or explicitly marked out of scope? [Gap, Spec §Dependencies, Spec §Out of Scope]

--- a/specs/001-build-a-gemini/plan.md
+++ b/specs/001-build-a-gemini/plan.md
@@ -5,24 +5,18 @@
 
 ## Summary
 
-Build a Rust-based Gemini CLI extension that aggregates third-party extension catalogs, parses `gemini-extension.json` manifests, and delivers searchable, cached marketplace discovery with namespaced identifiers, rate-limit aware refresh, and private-source support via existing Git credentials.
+Build a Rust-based Gemini CLI extension that reads third-party catalogs from GitHub, parses `gemini-extension.json` manifests, and presents searchable, cached marketplace listings. Retain namespacing, rate-limit awareness, and private-source support to allow Gemini CLI users to jump between corporate and public sources during a single session.
 
 ## Technical Context
 
-<!--
-  ACTION REQUIRED: Replace the content in this section with the technical details
-  for the project. The structure here is presented in advisory capacity to guide
-  the iteration process.
--->
-
-**Language/Version**: Rust 1.82.0 (MSRV aligned with Gemini CLI extension tooling)  
-**Primary Dependencies**: reqwest + tokio (HTTP), serde/serde_json (manifests), directories (config paths), thiserror/anyhow (errors), indicatif (UX); dev: assert_cmd, insta, wiremock  
-**Storage**: Per-source JSON cache under `$GEMINI_CONFIG/extensions/marketplace/` with TTL metadata and manual refresh  
-**Testing**: `cargo test` unit coverage plus assert_cmd CLI contracts, wiremock-backed integration tests with insta snapshots  
+**Language/Version**: Rust 1.82.0 (MSRV aligned with Gemini CLI extension tooling; newer ICU crates require ≥1.82)  
+**Primary Dependencies**: reqwest + tokio (HTTP), serde/serde_json (manifests), directories (config paths), thiserror/anyhow (errors), indicatif (UX); dev: assert_cmd, insta, wiremock, humantime, axum. These libraries match the Gemini CLI ecosystem, in order to bundle the extension without extra native deps.  
+**Storage**: Per-source JSON cache under `$GEMINI_CONFIG/extensions/marketplace/` with TTL metadata and manual refresh. Avoid SQLite to keep the cache inspectable and version-control friendly.  
+**Testing**: `cargo test` unit coverage plus assert_cmd CLI contracts, wiremock-backed integration tests with insta snapshots. This keeps the test loop fast while allowing for Gemini-native invocation.
 **Target Platform**: Linux and macOS official; Windows 11+ best-effort via directories crate and documented caveats  
 **Project Type**: Rust CLI extension crate integrated with Gemini CLI  
-**Performance Goals**: List rendering ≤2s from cache; remote fetch optimized via search-before-fetch when enabled  
-**Constraints**: Must queue refresh under GitHub rate limits; must avoid storing credentials; offline cache availability  
+**Performance Goals**: List rendering ≤2s from cache; remote fetch optimized via search-before-fetch when enabled. Maintain these thresholds such that CLI users don’t wait longer than Gemini’s typical command latency.  
+**Constraints**: Must queue refresh under GitHub rate limits; must avoid storing credentials; offline cache availability. These guardrails come from Gemini CLI trust requirements and from the constitution’s “no credential storage” stance.  
 **Scale/Scope**: Initial release covers default curated source + user-added sources (dozens of extensions, low concurrency)
 
 ## Constitution Check
@@ -50,12 +44,6 @@ specs/001-build-a-gemini/
 ```
 
 ### Source Code (repository root)
-<!--
-  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
-  for this feature. Delete unused options and expand the chosen structure with
-  real paths (e.g., apps/admin, packages/something). The delivered plan must
-  not include Option labels.
--->
 
 ```
 src/
@@ -76,6 +64,26 @@ tests/
 
 ## Complexity Tracking
 
-*Fill ONLY if Constitution Check has violations that must be justified*
-
 No constitution violations require justification at this time.
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+1. Complete Phases 1–2 to establish the crate, infrastructure, and services.
+2. Deliver Phase 3 (US1) to provide browsing capability — this is the minimum viable marketplace.
+3. Validate via T024–T030 and ensure cached listings function before proceeding. Commit and push a PR covering setup + US1.
+
+### Incremental Delivery
+1. Ship US1 (P1) for initial marketplace visibility.
+2. Layer on US2 (P2) to add detail views without disrupting listing functionality.
+3. Introduce US3 (P3) to improve discoverability through search/filtering.
+4. Finish with US4 (P4) for source management, observability, preferences, and refresh/status tooling, committing after each story.
+5. Run the Gemini CLI integration phase to exercise `gemini marketplace` commands end-to-end and push a pre-release validation PR.
+6. Apply final polish tasks before requesting review or release (final release PR).
+
+### Parallel Team Strategy
+1. Team collaborates on Phases 1–2.
+2. Assign US1 to Developer A to secure MVP while Developer B prepares US2 service extensions once T026 is merged.
+3. Developer C can begin US4 observability groundwork (T041, T051) after foundational tasks using mocks.
+4. Upon completion of US4, dedicate bandwidth to Phase 7 integration checks before moving to polish.
+5. Use the parallel opportunities list in `tasks.md` to avoid file conflicts and maintain independent delivery per story.

--- a/specs/001-build-a-gemini/plan.md
+++ b/specs/001-build-a-gemini/plan.md
@@ -10,9 +10,9 @@ Build a Rust-based Gemini CLI extension that reads third-party catalogs from Git
 ## Technical Context
 
 **Language/Version**: Rust 1.82.0 (MSRV aligned with Gemini CLI extension tooling; newer ICU crates require ≥1.82)  
-**Primary Dependencies**: reqwest + tokio (HTTP), serde/serde_json (manifests), directories (config paths), thiserror/anyhow (errors), indicatif (UX); dev: assert_cmd, insta, wiremock, humantime, axum. These libraries match the Gemini CLI ecosystem, in order to bundle the extension without extra native deps.  
+**Primary Dependencies**: reqwest + tokio (HTTP), serde/serde_json (manifests), directories (config paths), thiserror/anyhow (errors), indicatif (UX); dev stack: assert_cmd, insta, predicates, humantime, axum (for in-process test servers). These libraries match the Gemini CLI ecosystem, letting us bundle the extension without extra native deps.  
 **Storage**: Per-source JSON cache under `$GEMINI_CONFIG/extensions/marketplace/` with TTL metadata and manual refresh. Avoid SQLite to keep the cache inspectable and version-control friendly.  
-**Testing**: `cargo test` unit coverage plus assert_cmd CLI contracts, wiremock-backed integration tests with insta snapshots. This keeps the test loop fast while allowing for Gemini-native invocation.
+**Testing**: `cargo test` unit coverage plus assert_cmd CLI contracts and axum-backed integration tests. This keeps the test loop fast while invoking the CLI in a similar manner to Gemini.
 **Target Platform**: Linux and macOS official; Windows 11+ best-effort via directories crate and documented caveats  
 **Project Type**: Rust CLI extension crate integrated with Gemini CLI  
 **Performance Goals**: List rendering ≤2s from cache; remote fetch optimized via search-before-fetch when enabled. Maintain these thresholds such that CLI users don’t wait longer than Gemini’s typical command latency.  

--- a/specs/001-build-a-gemini/quickstart.md
+++ b/specs/001-build-a-gemini/quickstart.md
@@ -53,7 +53,7 @@ cargo build
    ```bash
    cargo test
    ```
-2. Execute integration suite (uses wiremock to simulate GitHub):
+2. Execute integration suite (uses axum-based test servers to simulate GitHub):
    ```bash
    cargo test --test integration
    ```

--- a/specs/001-build-a-gemini/research.md
+++ b/specs/001-build-a-gemini/research.md
@@ -16,9 +16,9 @@ Rationale: JSON aligns with manifest schema (`gemini-extension.json`), keeps tro
 Alternatives considered: SQLite was rejected as overkill for the expected dataset size; in-memory-only caches were rejected because offline browsing is a requirement; a single cache file was rejected to simplify partial invalidation.
 
 ## Testing Strategy
-Decision: Adopt layered testing with `cargo test` for unit coverage, `assert_cmd`-powered CLI contract tests for marketplace commands, and `insta` snapshots for deterministic render output. Network interactions will be exercised via mocked GitHub responses using `wiremock` under integration tests.  
-Rationale: The spec emphasizes testable acceptance criteria and accurate display formatting; combining unit + contract + snapshot testing enforces behavior without relying on live APIs. `wiremock` enables rate-limit and failure scenarios to be reproduced locally.  
-Alternatives considered: Live GitHub integration tests were rejected due to rate-limit unpredictability; relying solely on unit tests was rejected because CLI UX regressions would be missed; custom HTTP stubs were rejected because `wiremock` accelerates test authoring.
+Decision: Adopt layered testing with `cargo test` for unit coverage, `assert_cmd`-powered CLI contract tests for marketplace commands, and `insta` snapshots for deterministic render output. Network interactions use axum-backed test servers so we can simulate rate limits and catalog shifts without pulling binaries.  
+Rationale: The spec emphasizes testable acceptance criteria and accurate display formatting; combining unit + contract + snapshot testing enforces behavior without relying on live APIs. Axum lets us script failure modes (rate limits, malformed manifests) while staying in-process.  
+Alternatives considered: Live GitHub integration tests were rejected due to rate-limit unpredictability; relying solely on unit tests was rejected because CLI UX regressions would be missed; external mocking frameworks were avoided to reduce MSRV and dependency churn.
 
 ## Target Platform Support
 Decision: Officially support Linux and macOS hosts (matching Gemini CLI’s primary targets) and treat Windows 11+ as best-effort by leveraging the `directories` crate, avoiding symlinks, and documenting PowerShell-specific notes in quickstart.  

--- a/specs/001-build-a-gemini/spec.md
+++ b/specs/001-build-a-gemini/spec.md
@@ -18,6 +18,7 @@
 - Q: How should the marketplace handle an extension repository when its root gemini-extension.json manifest is missing or fails validation? → A: Skip the extension, continue processing, and surface a warning in results
 - Q: How should the marketplace authenticate when a custom source requires private Git access? → A: Rely on existing Git credential helpers or environment variables without storing credentials
 - Q: What level of observability should the marketplace extension guarantee for troubleshooting and monitoring? → A: Dual-mode logs plus structured metrics (e.g., counters for cache hits, rate-limit waits)
+- Q: Which repository should ship as the default curated marketplace source at launch? → A: https://github.com/athola/gemini-marketplace (kept under our control so test data stays stable)
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -103,6 +104,7 @@ As a Gemini CLI user, I want to add custom marketplace sources so that I can acc
 - **FR-003**: System MUST allow users to view detailed information for any listed extension
 - **FR-004**: System MUST provide the GitHub repository URL for each extension to enable manual installation
 - **FR-005**: System MUST support at least one default marketplace source containing publicly available Gemini CLI extensions
+- **FR-005a**: The default curated marketplace source MUST be seeded from `https://github.com/athola/gemini-marketplace` and remain enabled unless the user explicitly disables it
 - **FR-006**: System MUST allow users to search extensions by keyword (supporting partial or full matches) in name or description, with two modes: (1) fetch all extensions from all sources then filter locally, or (2) optionally apply search filters to marketplace API requests before fetching to minimize API calls and improve performance
 - **FR-007**: System MUST allow users to add custom marketplace sources via GitHub repository URLs or git URLs
 - **FR-008**: System MUST allow users to list all configured marketplace sources

--- a/specs/001-build-a-gemini/tasks.md
+++ b/specs/001-build-a-gemini/tasks.md
@@ -18,10 +18,10 @@
 
 **Purpose**: Project initialization and baseline tooling
 
-- [ ] T001 [Setup] Scaffold Rust crate with `Cargo.toml`, `src/lib.rs`, and `src/bin/marketplace.rs` aligned to the planned structure
-- [ ] T002 [Setup] Declare required crates in `Cargo.toml` (`tokio`, `reqwest`, `serde`, `directories`, `thiserror`, `anyhow`, `indicatif`, dev `assert_cmd`, `insta`, `wiremock`)
-- [ ] T003 [Setup] Add repository-wide tooling configs (`rust-toolchain.toml`, `.cargo/config.toml`, `clippy.toml`) enforcing Rust 1.82.0 and lint rules
-- [ ] T004 [Setup] Create testing scaffolds (`tests/integration/`, `tests/unit/`, `tests/common/mod.rs`) with placeholder harness setup
+- [X] T001 [Setup] Scaffold Rust crate with `Cargo.toml`, `src/lib.rs`, and `src/bin/marketplace.rs` aligned to the planned structure
+- [X] T002 [Setup] Declare required crates in `Cargo.toml` (`tokio`, `reqwest`, `serde`, `directories`, `thiserror`, `anyhow`, `indicatif`, dev `assert_cmd`, `insta`, `wiremock`)
+- [X] T003 [Setup] Add repository-wide tooling configs (`rust-toolchain.toml`, `.cargo/config.toml`, `clippy.toml`) enforcing Rust 1.82.0 and lint rules
+- [X] T004 [Setup] Create testing scaffolds (`tests/integration/`, `tests/unit/`, `tests/common/mod.rs`) with placeholder harness setup
 
 ---
 
@@ -31,17 +31,27 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T005 [Foundation] Scaffold `src/marketplace/` module tree with stub files (`mod.rs`, `commands/mod.rs`, `services/mod.rs`, `models/{manifest.rs,domain.rs}`, `cache/mod.rs`, `api/mod.rs`)
-- [ ] T006 [P] [Foundation] Implement configuration helpers in `src/marketplace/config.rs` to resolve cache and preferences directories using the `directories` crate
-- [ ] T007 [P] [Foundation] Introduce shared error enums and result aliases in `src/marketplace/error.rs` leveraging `thiserror`
-- [ ] T008 [Foundation] Parse `gemini-extension.json` manifests in `src/marketplace/models/manifest.rs`, including validation and warning aggregation
-- [ ] T009 [Foundation] Model domain entities and install state in `src/marketplace/models/domain.rs` per `data-model.md`
-- [ ] T010 [Foundation] Implement JSON cache store with TTL metadata in `src/marketplace/cache/store.rs`
-- [ ] T011 [Foundation] Build source fetcher with GitHub rate-limit queue handling in `src/marketplace/services/source_fetcher.rs`
-- [ ] T012 [Foundation] Set up Clap-driven CLI bootstrap and command routing skeleton in `src/bin/marketplace.rs`
-- [ ] T013 [Foundation] Implement lightweight HTTP server harness in `src/marketplace/api/server.rs` ready to host OpenAPI routes
+- [X] T005 [Foundation] Scaffold `src/marketplace/` module tree with stub files (`mod.rs`, `commands/mod.rs`, `services/mod.rs`, `models/{manifest.rs,domain.rs}`, `cache/mod.rs`, `api/mod.rs`)
+- [X] T006 [Foundation] Write unit tests for configuration helper path resolution in `tests/unit/config.rs`
+- [X] T007 [Foundation] Implement configuration helpers in `src/marketplace/config.rs` to resolve cache and preferences directories using the `directories` crate
+- [X] T008 [Foundation] Write unit tests for shared error mappings in `tests/unit/error.rs`
+- [X] T009 [Foundation] Introduce shared error enums and result aliases in `src/marketplace/error.rs` leveraging `thiserror`
+- [X] T010 [Foundation] Write unit tests for manifest parsing/normalization in `tests/unit/manifest.rs`
+- [X] T011 [Foundation] Parse `gemini-extension.json` manifests in `src/marketplace/models/manifest.rs`, including validation and warning aggregation
+- [X] T012 [Foundation] Write unit tests for domain entities and install state transitions in `tests/unit/domain.rs`
+- [X] T013 [Foundation] Model domain entities and install state in `src/marketplace/models/domain.rs` per `data-model.md`
+- [X] T014 [Foundation] Write integration tests for JSON cache persistence in `tests/integration/cache_store.rs`
+- [X] T015 [Foundation] Implement JSON cache store with TTL metadata in `src/marketplace/cache/store.rs`
+- [X] T016 [Foundation] Write integration tests for source synchronization with rate-limit simulation in `tests/integration/source_fetcher.rs`
+- [X] T017 [Foundation] Build source fetcher with GitHub rate-limit queue handling in `src/marketplace/services/source_fetcher.rs`
+- [X] T018 [Foundation] Write CLI parsing tests using `assert_cmd` for command routing in `tests/integration/cli_parse.rs`
+- [X] T019 [Foundation] Set up Clap-driven CLI bootstrap and command routing skeleton in `src/bin/marketplace.rs`
+- [X] T020 [Foundation] Write integration tests for Axum server bootstrap in `tests/integration/api_server.rs`
+- [X] T021 [Foundation] Implement lightweight HTTP server harness in `src/marketplace/api/server.rs` ready to host OpenAPI routes
+- [ ] T022 [Foundation] Write unit tests for default curated source configuration in `tests/unit/default_source.rs`
+- [ ] T023 [Foundation] Seed default curated marketplace source configuration and validation logic in `src/marketplace/services/sources.rs`
 
-**Checkpoint**: Foundation ready — user story implementation can now begin
+**Checkpoint**: Foundation ready — user story implementation can now begin **(commit & open PR with setup/foundation)**
 
 ---
 
@@ -53,16 +63,18 @@
 
 ### Tests for User Story 1
 
-- [ ] T014 [US1] Author `tests/integration/list_extensions.rs` using `wiremock` + `assert_cmd` + `insta` to assert list output, caching, and warning behavior when manifests are skipped
+- [X] T024 [US1] Author `tests/integration/list_extensions.rs` using `wiremock` + `assert_cmd` to assert list output, caching, and warning behavior when manifests are skipped
+- [X] T025 [US1] Write tests for network failure messaging and cache fallback in `tests/integration/list_extensions.rs`
 
 ### Implementation for User Story 1
 
-- [ ] T015 [US1] Implement listing workflow in `src/marketplace/services/catalog.rs` to merge cache, fetch manifests, compute install status, and skip invalid manifests with warnings
-- [ ] T016 [P] [US1] Render tabular and JSON outputs in `src/marketplace/commands/list.rs`, including namespace formatting and pagination support
-- [ ] T017 [US1] Wire the `list` command and options into Clap routing within `src/bin/marketplace.rs`
-- [ ] T018 [P] [US1] Expose `GET /marketplace/extensions` handler in `src/marketplace/api/extensions.rs` returning `ExtensionListResponse`
+- [X] T026 [US1] Implement listing workflow in `src/marketplace/services/catalog.rs` to merge cache, fetch manifests, compute install status, and skip invalid manifests with warnings
+- [X] T027 [P] [US1] Render tabular and JSON outputs in `src/marketplace/commands/list.rs`, including namespace formatting and pagination support
+- [X] T028 [US1] Wire the `list` command and options into Clap routing within `src/bin/marketplace.rs`
+- [ ] T029 [P] [US1] Expose `GET /marketplace/extensions` handler in `src/marketplace/api/extensions.rs` returning `ExtensionListResponse`
+- [X] T030 [US1] Implement graceful network-error messaging and fallback pathways across CLI and API list flows
 
-**Checkpoint**: User Story 1 independently testable (MVP)
+**Checkpoint**: User Story 1 independently testable (MVP) **(commit & extend PR or open US1 PR)**
 
 ---
 
@@ -74,16 +86,16 @@
 
 ### Tests for User Story 2
 
-- [ ] T019 [US2] Create `tests/integration/view_extension_details.rs` covering detail retrieval, README excerpt rendering, and missing extension 404 handling
+- [ ] T031 [US2] Create `tests/integration/view_extension_details.rs` covering detail retrieval, README excerpt rendering, and missing extension 404 handling
 
 ### Implementation for User Story 2
 
-- [ ] T020 [US2] Extend `src/marketplace/services/catalog.rs` with detail retrieval, README extraction, and manifest checksum exposure
-- [ ] T021 [P] [US2] Implement `show` command presenter in `src/marketplace/commands/show.rs` with rich formatting and error messaging
-- [ ] T022 [US2] Register `show` subcommand and arguments in `src/bin/marketplace.rs`
-- [ ] T023 [P] [US2] Add `GET /marketplace/extensions/{extensionId}` route in `src/marketplace/api/extensions.rs` returning `ExtensionDetail`
+- [ ] T032 [US2] Extend `src/marketplace/services/catalog.rs` with detail retrieval, README extraction, and manifest checksum exposure
+- [ ] T033 [P] [US2] Implement `show` command presenter in `src/marketplace/commands/show.rs` with rich formatting and error messaging
+- [ ] T034 [US2] Register `show` subcommand and arguments in `src/bin/marketplace.rs`
+- [ ] T035 [P] [US2] Add `GET /marketplace/extensions/{extensionId}` route in `src/marketplace/api/extensions.rs` returning `ExtensionDetail`
 
-**Checkpoint**: User Stories 1 & 2 independently deliverable
+**Checkpoint**: User Stories 1 & 2 independently deliverable **(commit & open/extend PR for US2)**
 
 ---
 
@@ -95,15 +107,15 @@
 
 ### Tests for User Story 3
 
-- [ ] T024 [US3] Add `tests/integration/search_extensions.rs` to verify local filtering, pre-fetch optimization toggles, category filtering, and installed-only views
+- [ ] T036 [US3] Add `tests/integration/search_extensions.rs` to verify local filtering, pre-fetch optimization toggles, category filtering, and installed-only views
 
 ### Implementation for User Story 3
 
-- [ ] T025 [US3] Enhance `src/marketplace/services/catalog.rs` with search/filter parameters, pre-fetch optimization, and metrics for filtered counts
-- [ ] T026 [P] [US3] Extend `src/marketplace/commands/list.rs` to accept `--search`, `--category`, `--source`, and `--installed` flags plus toggle for pre-fetch mode
-- [ ] T027 [P] [US3] Update `src/marketplace/api/extensions.rs` to parse query params and delegate to the enhanced search logic
+- [ ] T037 [US3] Enhance `src/marketplace/services/catalog.rs` with search/filter parameters, pre-fetch optimization, and metrics for filtered counts
+- [ ] T038 [P] [US3] Extend `src/marketplace/commands/list.rs` to accept `--search`, `--category`, `--source`, and `--installed` flags plus toggle for pre-fetch mode
+- [ ] T039 [P] [US3] Update `src/marketplace/api/extensions.rs` to parse query params and delegate to the enhanced search logic
 
-**Checkpoint**: User Stories 1–3 independently testable
+**Checkpoint**: User Stories 1–3 independently testable **(commit & open/extend PR for US3)**
 
 ---
 
@@ -115,30 +127,43 @@
 
 ### Tests for User Story 4
 
-- [ ] T028 [US4] Create `tests/integration/manage_sources.rs` covering add/list/remove, preference persistence (TTL & search mode), refresh queuing, and credential-helper reliance
+- [ ] T040 [US4] Create `tests/integration/manage_sources.rs` covering add/list/remove, preference persistence (TTL & search mode), refresh queuing, and credential-helper reliance
+- [ ] T041 [US4] Write tests for dual-mode logging and metrics emission in `tests/integration/observability.rs`
 
 ### Implementation for User Story 4
 
-- [ ] T029 [US4] Persist user preferences (TTL, search mode) in `src/marketplace/services/preferences.rs` and expose safe getters/setters
-- [ ] T030 [US4] Implement source registry lifecycle in `src/marketplace/services/sources.rs`, including validation, namespacing, and skip warnings
-- [ ] T031 [P] [US4] Build `sources` CLI subcommands in `src/marketplace/commands/sources.rs` for add/list/remove utilizing preference + source services
-- [ ] T032 [US4] Register nested `sources` CLI tree within `src/bin/marketplace.rs`
-- [ ] T033 [P] [US4] Implement `/marketplace/sources` REST routes in `src/marketplace/api/sources.rs` (GET/POST/DELETE) aligned to OpenAPI contract
-- [ ] T034 [US4] Implement refresh scheduler and rate-limit countdown in `src/marketplace/services/refresh.rs`
-- [ ] T035 [P] [US4] Add CLI commands in `src/marketplace/commands/refresh.rs` for manual refresh and status inspection
-- [ ] T036 [P] [US4] Expose `/marketplace/cache/refresh` and `/marketplace/status` endpoints in `src/marketplace/api/status.rs` returning queue + cache metrics
+- [ ] T042 [US4] Persist user preferences (TTL, search mode) in `src/marketplace/services/preferences.rs` and expose safe getters/setters
+- [ ] T043 [US4] Implement source registry lifecycle in `src/marketplace/services/sources.rs`, including validation, namespacing, and skip warnings
+- [ ] T044 [P] [US4] Build `sources` CLI subcommands in `src/marketplace/commands/sources.rs` for add/list/remove utilizing preference + source services
+- [ ] T045 [US4] Register nested `sources` CLI tree within `src/bin/marketplace.rs`
+- [ ] T046 [P] [US4] Implement `/marketplace/sources` REST routes in `src/marketplace/api/sources.rs` (GET/POST/DELETE) aligned to OpenAPI contract
+- [ ] T047 [US4] Implement refresh scheduler and rate-limit countdown in `src/marketplace/services/refresh.rs`
+- [ ] T048 [P] [US4] Add CLI commands in `src/marketplace/commands/refresh.rs` for manual refresh and status inspection
+- [ ] T049 [P] [US4] Expose `/marketplace/cache/refresh` and `/marketplace/status` endpoints in `src/marketplace/api/status.rs` returning queue + cache metrics
+- [ ] T050 [US4] Implement credential-helper detection, warnings, and documentation hooks in `src/marketplace/services/sources.rs`
+- [ ] T051 [US4] Implement dual-mode logging and structured metrics emission across CLI and API paths
 
-**Checkpoint**: All user stories complete and independently verifiable
+**Checkpoint**: All user stories complete and independently verifiable **(commit & open/extend PR for US4)**
 
 ---
 
-## Phase 7: Polish & Cross-Cutting Concerns
+## Phase 7: Gemini CLI Integration (Pre-Release)
+
+**Purpose**: Validate the extension when invoked through the Gemini CLI binary. Keep this phase separate to prevent breakages in Gemini’s loader surface before polish work begins. **(commit once integration checks pass; consider pre-release PR)**
+
+- [ ] T052 [Integration] Create integration harness to link the built extension via `gemini extensions path add` and manage temporary config overrides
+- [ ] T053 [Integration] Execute smoke tests (`gemini marketplace list/show/status`) against mock data, capturing outputs for regression comparison
+- [ ] T054 [Integration] Document Gemini CLI integration workflow in `docs/integration.md` (or similar) for repeatable validation steps
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
 
 **Purpose**: Repository-wide QA and documentation alignment
 
-- [ ] T037 [Polish] Update `quickstart.md` with final CLI commands, Windows notes for credential helpers, and testing instructions
-- [ ] T038 [Polish] Add developer-facing usage docs/README snippet under `docs/marketplace.md` summarizing commands and API endpoints
-- [ ] T039 [Polish] Run `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and full `cargo test` to ensure clean build before review
+- [ ] T055 [Polish] Update `quickstart.md` with final CLI commands, Windows notes for credential helpers, and testing instructions
+- [ ] T056 [Polish] Update `README.md` / `docs/marketplace.md` summary with observability + credential guidance aligned to NFR-001 and FR-013c
+- [ ] T057 [Polish] Run `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and full `cargo test` to ensure clean build before review **(final commit & release PR)**
 
 ---
 
@@ -146,40 +171,43 @@
 
 ### Phase Dependencies
 - **Phase 1 → Phase 2**: Foundational work depends on crate/tooling setup (T001–T004).
-- **Phase 2 → Phases 3–6**: All user story phases require foundational modules, config, cache, and server scaffolding (T005–T013).
-- **Phase 3 (US1)**: Must finish before later stories to supply shared catalog capabilities.
-- **Phase 4 (US2)** and **Phase 5 (US3)**: Depend on US1 service infrastructure but can start once US1 service (T015) is stable.
-- **Phase 6 (US4)**: Depends on Phase 2 infrastructure and US1 cache/service mechanics.
-- **Phase 7 (Polish)**: Runs after desired user stories are complete.
+- **Phase 2 → Phases 3–6**: All user story phases require foundational modules, config, cache, server scaffolding, and default source (T005–T023).
+- **Phase 3 (US1)**: Must finish before later stories to supply shared catalog capabilities and network error handling.
+- **Phase 4 (US2)** and **Phase 5 (US3)**: Depend on US1 service infrastructure but can start once listing service (T026) is stable.
+- **Phase 6 (US4)**: Depends on Phase 2 infrastructure and US1 catalog logic.
+- **Phase 7 (Integration)**: Runs after user story implementation to validate Gemini CLI end-to-end behavior.
+- **Phase 8 (Polish)**: Executes once integration checks are complete.
 
 ### User Story Dependencies
 - **US1**: Independent after foundational phase; delivers MVP.
 - **US2**: Depends on US1’s catalog foundations.
 - **US3**: Builds on US1 listing logic to extend search/filtering.
-- **US4**: Extends shared services and introduces new management modules; does not block earlier stories.
+- **US4**: Extends shared services and introduces new management + observability modules; does not block earlier stories.
 
 ### Within-Story Ordering Highlights
-- Tests (T014, T019, T024, T028) precede implementation tasks for their stories.
-- Services (T015, T020, T025, T030, T034) land before CLI/API wiring tasks that rely on them.
-- CLI wiring in `src/bin/marketplace.rs` (T017, T022, T032) must follow individual command implementations.
+- Tests precede implementation tasks for every feature per constitution (e.g., T010 → T011, T024 → T026).
+- Services (T026, T032, T037, T043, T047) land before CLI/API wiring tasks that rely on them.
+- CLI wiring in `src/bin/marketplace.rs` (T028, T034, T045) must follow individual command implementations.
+- Integration harness tasks (T052–T054) should use built artifacts from prior phases.
 
 ---
 
 ## Parallel Opportunities
-- **Foundation**: After T005, configuration (T006) and error handling (T007) can progress in parallel.
-- **US1**: Once catalog logic (T015) is in place, CLI rendering (T016) and REST route (T018) can proceed concurrently.
-- **US2**: Detail command (T021) and API route (T023) operate in different files post-service update (T020).
-- **US3**: After enhancing the service (T025), CLI flag wiring (T026) and API query parsing (T027) can run side by side.
-- **US4**: With services ready (T030, T034), CLI commands (T031, T035) and HTTP routes (T033, T036) offer multiple parallel tracks.
+- **Foundation**: After T005 scaffolds modules, configuration (T006–T007) and error handling (T008–T009) can proceed alongside manifest work; cache (T014–T015) and fetcher (T016–T017) can run in parallel once dependencies mocked.
+- **US1**: Following T026 service completion, CLI rendering (T027) and REST route (T029) can progress concurrently while network-error work (T030) finalizes messaging.
+- **US2**: Detail command (T033) and API route (T035) operate in different files post-service update (T032).
+- **US3**: With T037 done, CLI flag wiring (T038) and API query parsing (T039) can run side by side.
+- **US4**: After T043 and T047 establish services, CLI commands (T044, T048) and HTTP routes (T046, T049) offer multiple parallel tracks, while observability (T041, T051) can execute with minimal overlap.
+- **Integration**: Gemini CLI smoke checks (T052–T054) rely on compiled binaries; these can run concurrently once US4 is done.
 
 ---
 
 ## Parallel Execution Examples
 
-- **User Story 1**: After completing T015, run T016 and T018 simultaneously to implement CLI and API surfaces for listing.
-- **User Story 2**: Following T020, split work so one developer handles T021 (CLI presenter) while another handles T023 (detail API route).
-- **User Story 3**: With T025 done, execute T026 (CLI flags) and T027 (API query parsing) in parallel to cover both interfaces.
-- **User Story 4**: Once T030 and T034 are finished, parallelize T031/T035 (CLI subcommands) and T033/T036 (REST endpoints).
+- **User Story 1**: After completing T026, run T027 and T029 simultaneously to implement CLI and API surfaces for listing.
+- **User Story 2**: Following T032, split work so one developer handles T033 (CLI presenter) while another handles T035 (detail API route).
+- **User Story 3**: With T037 done, execute T038 (CLI flags) and T039 (API query parsing) in parallel to cover both interfaces.
+- **User Story 4**: Once T043 and T047 are finished, parallelize T044/T048 (CLI subcommands) and T046/T049 (REST endpoints), while observability tasks (T041, T051) run independently.
 
 ---
 
@@ -188,21 +216,21 @@
 ### MVP First (User Story 1 Only)
 1. Complete Phases 1–2 to establish the crate, infrastructure, and services.
 2. Deliver Phase 3 (US1) to provide browsing capability — this is the minimum viable marketplace.
-3. Validate via T014 and ensure cached listings function before proceeding.
+3. Validate via T024–T030 and ensure cached listings function before proceeding.
 
 ### Incremental Delivery
 1. Ship US1 (P1) for initial marketplace visibility.
 2. Layer on US2 (P2) to add detail views without disrupting listing functionality.
 3. Introduce US3 (P3) to improve discoverability through search/filtering.
-4. Finish with US4 (P4) for source management, preferences, and refresh/status tooling.
-5. Apply Phase 7 polish tasks before requesting review or release.
+4. Finish with US4 (P4) for source management, observability, preferences, and refresh/status tooling.
+5. Run Phase 7 integration tasks to validate Gemini CLI end-to-end behavior.
+6. Apply Phase 8 polish tasks before requesting review or release.
 
 ### Parallel Team Strategy
 1. Team collaborates on Phases 1–2.
-2. Assign US1 to Developer A to secure MVP.
-3. While US1 stabilizes, Developer B can begin US2 service extensions once T015 is merged.
-4. Developer C can prepare US4 services in parallel after foundational tasks, aligning integrations once US1 service contracts are stable.
-5. Use the parallel opportunities list to avoid file conflicts and maintain independent delivery per story.
+2. Assign US1 to Developer A to secure MVP while Developer B prepares US2 service extensions once T026 is merged.
+3. Developer C can begin US4 observability groundwork (T041, T051) after foundational tasks using mocks.
+4. Use the parallel opportunities list to avoid file conflicts and maintain independent delivery per story.
 
 ---
 

--- a/specs/001-build-a-gemini/tasks.md
+++ b/specs/001-build-a-gemini/tasks.md
@@ -3,7 +3,7 @@
 **Input**: Design documents from `specs/001-build-a-gemini/`
 **Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
 
-**Tests**: Integration tests are requested via the spec’s independent test criteria and plan’s testing strategy. Each user story phase includes targeted tests using `assert_cmd`, `wiremock`, and `insta`.
+**Tests**: Integration tests are requested via the spec’s independent test criteria and plan’s testing strategy. Each user story phase includes targeted tests using `assert_cmd`, axum-backed test servers, and `insta` snapshots.
 
 **Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
 
@@ -19,7 +19,7 @@
 **Purpose**: Project initialization and baseline tooling
 
 - [X] T001 [Setup] Scaffold Rust crate with `Cargo.toml`, `src/lib.rs`, and `src/bin/marketplace.rs` aligned to the planned structure
-- [X] T002 [Setup] Declare required crates in `Cargo.toml` (`tokio`, `reqwest`, `serde`, `directories`, `thiserror`, `anyhow`, `indicatif`, dev `assert_cmd`, `insta`, `wiremock`)
+- [X] T002 [Setup] Declare required crates in `Cargo.toml` (`tokio`, `reqwest`, `serde`, `directories`, `thiserror`, `anyhow`, `indicatif`, dev `assert_cmd`, `insta`, `predicates`)
 - [X] T003 [Setup] Add repository-wide tooling configs (`rust-toolchain.toml`, `.cargo/config.toml`, `clippy.toml`) enforcing Rust 1.82.0 and lint rules
 - [X] T004 [Setup] Create testing scaffolds (`tests/integration/`, `tests/unit/`, `tests/common/mod.rs`) with placeholder harness setup
 
@@ -63,7 +63,7 @@
 
 ### Tests for User Story 1
 
-- [X] T024 [US1] Author `tests/integration/list_extensions.rs` using `wiremock` + `assert_cmd` to assert list output, caching, and warning behavior when manifests are skipped
+- [X] T024 [US1] Author `tests/integration/list_extensions.rs` using an in-process axum test server + `assert_cmd` to assert list output, caching, and warning behavior when manifests are skipped
 - [X] T025 [US1] Write tests for network failure messaging and cache fallback in `tests/integration/list_extensions.rs`
 
 ### Implementation for User Story 1

--- a/src/bin/marketplace.rs
+++ b/src/bin/marketplace.rs
@@ -2,6 +2,8 @@ use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
 
+use gemini_marketplace::marketplace::commands::list::{execute as execute_list, ListOptions};
+
 #[derive(Debug, Parser)]
 #[command(
     name = "gemini-marketplace",
@@ -80,12 +82,25 @@ enum SourcesCommand {
     },
 }
 
-fn main() -> ExitCode {
+#[tokio::main]
+async fn main() -> ExitCode {
     let cli = MarketplaceCli::parse();
     let result = match cli.command {
-        MarketplaceCommand::List { .. } => {
-            // TODO: invoke list command once implemented
-            Ok(())
+        MarketplaceCommand::List {
+            search,
+            category,
+            source,
+            installed,
+            json,
+        } => {
+            execute_list(ListOptions {
+                search,
+                category,
+                source,
+                installed_only: installed,
+                json,
+            })
+            .await
         }
         MarketplaceCommand::Show { .. } => Ok(()),
         MarketplaceCommand::Sources { .. } => Ok(()),

--- a/src/marketplace/api/server.rs
+++ b/src/marketplace/api/server.rs
@@ -6,7 +6,7 @@
 use std::net::SocketAddr;
 
 use axum::Router;
-use tokio::task::JoinHandle;
+use tokio::{net::TcpListener, task::JoinHandle};
 
 use crate::marketplace::api::{extensions, sources, status};
 use crate::marketplace::error::{MarketplaceError, Result};
@@ -31,14 +31,22 @@ impl ApiServer {
     }
 
     pub async fn run(self, addr: SocketAddr) -> Result<()> {
-        axum::Server::bind(&addr)
-            .serve(self.router.into_make_service())
+        let listener = TcpListener::bind(addr)
+            .await
+            .map_err(|err| MarketplaceError::Network(format!("API server bind error: {err}")))?;
+        axum::serve(listener, self.router.into_make_service())
             .await
             .map_err(|err| MarketplaceError::Network(format!("API server error: {err}")))
     }
 
     pub fn spawn(self, addr: SocketAddr) -> JoinHandle<Result<()>> {
         tokio::spawn(async move { self.run(addr).await })
+    }
+}
+
+impl Default for ApiServer {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/marketplace/api/sources.rs
+++ b/src/marketplace/api/sources.rs
@@ -2,7 +2,7 @@
 
 use axum::{
     http::StatusCode,
-    routing::{delete, get, post},
+    routing::{delete, get},
     Router,
 };
 

--- a/src/marketplace/cache/store.rs
+++ b/src/marketplace/cache/store.rs
@@ -30,6 +30,12 @@ struct CacheFile {
     pub extensions: Vec<Extension>,
 }
 
+#[derive(Debug, Clone)]
+pub struct CacheSnapshot {
+    pub entry: CacheEntry,
+    pub extensions: Vec<Extension>,
+}
+
 impl CacheStore {
     pub fn new(config: &Config) -> Result<Self> {
         let root = config.cache_dir();
@@ -41,7 +47,7 @@ impl CacheStore {
         self.root.join(format!("{source_slug}.json"))
     }
 
-    pub fn load(&self, source_slug: &str) -> Result<Option<CacheEntry>> {
+    pub fn load(&self, source_slug: &str) -> Result<Option<CacheSnapshot>> {
         let path = self.cache_path(source_slug);
         if !path.exists() {
             return Ok(None);
@@ -60,7 +66,7 @@ impl CacheStore {
             .map(|ext| ext.id.clone())
             .collect();
 
-        Ok(Some(CacheEntry {
+        let entry = CacheEntry {
             source_slug: source_slug.to_string(),
             manifest_checksum: cache_file
                 .extensions
@@ -72,7 +78,12 @@ impl CacheStore {
             fetched_at: cache_file.fetched_at,
             expires_at: cache_file.expires_at,
             extension_ids,
-            etag: cache_file.etag,
+            etag: cache_file.etag.clone(),
+        };
+
+        Ok(Some(CacheSnapshot {
+            entry,
+            extensions: cache_file.extensions,
         }))
     }
 
@@ -89,11 +100,17 @@ impl CacheStore {
             .checked_add(ttl)
             .ok_or_else(|| MarketplaceError::Configuration("Cache TTL overflow".into()))?;
 
+        let mut payload = extensions.to_vec();
+        for extension in &mut payload {
+            extension.cache_expires_at = Some(expires_at);
+            extension.last_synced_at = Some(fetched_at);
+        }
+
         let cache_file = CacheFile {
             fetched_at,
             expires_at,
             etag,
-            extensions: extensions.to_vec(),
+            extensions: payload,
         };
 
         let file = File::create(&path).map_err(|err| MarketplaceError::io(path.clone(), err))?;

--- a/src/marketplace/cache/store.rs
+++ b/src/marketplace/cache/store.rs
@@ -6,7 +6,7 @@
 
 use std::fs::{self, File};
 use std::io::{BufReader, BufWriter};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
 use serde::{Deserialize, Serialize};

--- a/src/marketplace/commands/list.rs
+++ b/src/marketplace/commands/list.rs
@@ -40,7 +40,10 @@ pub async fn execute(opts: ListOptions) -> Result<()> {
         category: opts.category.as_deref(),
         source: opts.source.as_deref(),
         installed_only: opts.installed_only,
-        prefetch_filter: matches!(service.preferences().search_mode(), SearchMode::PreFetchFilter),
+        prefetch_filter: matches!(
+            service.preferences().search_mode(),
+            SearchMode::PreFetchFilter
+        ),
     };
 
     let response = service.list(&request).await?;
@@ -88,4 +91,3 @@ fn render_table(entries: &[ListEntry]) {
         println!();
     }
 }
-*** End Patch

--- a/src/marketplace/commands/list.rs
+++ b/src/marketplace/commands/list.rs
@@ -1,7 +1,91 @@
-//! Placeholder implementation for the `list` command.
+use std::collections::BTreeMap;
+use std::io::{self, Write};
 
 use anyhow::Result;
+use serde::Serialize;
 
-pub fn execute() -> Result<()> {
-    anyhow::bail!("command not yet implemented");
+use crate::marketplace::config::Config;
+use crate::marketplace::models::domain::SearchMode;
+use crate::marketplace::services::catalog::{
+    default_preferences, default_sources, CatalogService, ListEntry, ListRequest,
+};
+use crate::marketplace::services::source_fetcher::SourceFetcher;
+
+#[derive(Debug, Clone)]
+pub struct ListOptions {
+    pub search: Option<String>,
+    pub category: Option<String>,
+    pub source: Option<String>,
+    pub installed_only: bool,
+    pub json: bool,
 }
+
+#[derive(Serialize)]
+struct CliListResponse<'a> {
+    entries: &'a [ListEntry],
+    warnings: &'a [String],
+}
+
+pub async fn execute(opts: ListOptions) -> Result<()> {
+    let config = Config::new()?;
+    config.ensure_dirs()?;
+
+    let prefs = default_preferences();
+    let sources = default_sources();
+    let fetcher = SourceFetcher::new(&config, prefs.clone())?;
+    let service = CatalogService::new(fetcher, prefs, sources);
+
+    let request = ListRequest {
+        search: opts.search.as_deref(),
+        category: opts.category.as_deref(),
+        source: opts.source.as_deref(),
+        installed_only: opts.installed_only,
+        prefetch_filter: matches!(service.preferences().search_mode(), SearchMode::PreFetchFilter),
+    };
+
+    let response = service.list(&request).await?;
+
+    for warning in &response.warnings {
+        writeln!(io::stderr(), "warning: {warning}")?;
+    }
+
+    if opts.json {
+        let payload = CliListResponse {
+            entries: &response.entries,
+            warnings: &response.warnings,
+        };
+        let json = serde_json::to_string_pretty(&payload)?;
+        println!("{json}");
+        return Ok(());
+    }
+
+    render_table(&response.entries);
+    Ok(())
+}
+
+fn render_table(entries: &[ListEntry]) {
+    if entries.is_empty() {
+        println!("No extensions found.");
+        return;
+    }
+
+    let mut grouped: BTreeMap<&str, Vec<&ListEntry>> = BTreeMap::new();
+    for entry in entries {
+        grouped.entry(&entry.source).or_default().push(entry);
+    }
+
+    for (source, items) in grouped {
+        println!("Source: {source}");
+        println!("{:<40} {:<}", "Extension", "Description");
+        println!("{:-<80}", "");
+        for item in items {
+            println!(
+                "{:<40} {}",
+                format!("{} ({})", item.display_name, item.version),
+                item.description
+            );
+        }
+        println!();
+    }
+}
+*** End Patch

--- a/src/marketplace/config.rs
+++ b/src/marketplace/config.rs
@@ -2,43 +2,63 @@
 //!
 //! Resolves platform-specific paths for cache, preferences, and logs using the
 //! `directories` crate so the extension remains portable across Linux, macOS,
-//! and Windows targets.
+//! and Windows targets. A `GEMINI_MARKETPLACE_HOME` override is available to
+//! support isolated testing.
 
-use std::path::PathBuf;
+use std::env;
+use std::path::{Path, PathBuf};
 
 use directories::{ProjectDirs, UserDirs};
+
+use crate::marketplace::error::{MarketplaceError, Result};
 
 const QUALIFIER: &str = "com";
 const ORGANIZATION: &str = "gemini";
 const APPLICATION: &str = "marketplace-extension";
+const ENV_OVERRIDE: &str = "GEMINI_MARKETPLACE_HOME";
 
 #[derive(Debug, Clone)]
 pub struct Config {
-    project_dirs: ProjectDirs,
+    cache_dir: PathBuf,
+    config_dir: PathBuf,
+    log_dir: PathBuf,
 }
 
 impl Config {
-    /// Construct configuration paths, returning an error when system user dirs
-    /// cannot be resolved (rare but indicates a misconfigured environment).
-    pub fn new() -> anyhow::Result<Self> {
+    /// Construct configuration paths, honoring the optional override env var for testing.
+    pub fn new() -> Result<Self> {
+        if let Ok(path) = env::var(ENV_OVERRIDE) {
+            let base = Path::new(&path).to_path_buf();
+            return Ok(Self {
+                cache_dir: base.join("cache"),
+                config_dir: base.join("config"),
+                log_dir: base.join("logs"),
+            });
+        }
+
         let project_dirs = ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION)
-            .ok_or_else(|| anyhow::anyhow!("Unable to resolve project directories"))?;
-        Ok(Self { project_dirs })
+            .ok_or_else(|| MarketplaceError::Configuration("Unable to resolve project directories".into()))?;
+
+        Ok(Self {
+            cache_dir: project_dirs.cache_dir().to_path_buf(),
+            config_dir: project_dirs.config_dir().to_path_buf(),
+            log_dir: project_dirs.data_local_dir().join("logs"),
+        })
     }
 
     /// Directory containing cache files (per-source JSON payloads, TTL metadata).
     pub fn cache_dir(&self) -> PathBuf {
-        self.project_dirs.cache_dir().to_path_buf()
+        self.cache_dir.clone()
     }
 
     /// Directory containing configuration files (user preferences, sources list).
     pub fn config_dir(&self) -> PathBuf {
-        self.project_dirs.config_dir().to_path_buf()
+        self.config_dir.clone()
     }
 
     /// Directory for logs or diagnostics produced by the extension.
     pub fn log_dir(&self) -> PathBuf {
-        self.project_dirs.data_local_dir().join("logs")
+        self.log_dir.clone()
     }
 
     /// User downloads directory, used as fallback when exporting manifests or reports.
@@ -47,10 +67,13 @@ impl Config {
     }
 
     /// Ensure required directories exist, creating them as needed.
-    pub fn ensure_dirs(&self) -> anyhow::Result<()> {
-        std::fs::create_dir_all(self.cache_dir())?;
-        std::fs::create_dir_all(self.config_dir())?;
-        std::fs::create_dir_all(self.log_dir())?;
+    pub fn ensure_dirs(&self) -> Result<()> {
+        std::fs::create_dir_all(&self.cache_dir)
+            .map_err(|err| MarketplaceError::io(self.cache_dir.clone(), err))?;
+        std::fs::create_dir_all(&self.config_dir)
+            .map_err(|err| MarketplaceError::io(self.config_dir.clone(), err))?;
+        std::fs::create_dir_all(&self.log_dir)
+            .map_err(|err| MarketplaceError::io(self.log_dir.clone(), err))?;
         Ok(())
     }
 }

--- a/src/marketplace/config.rs
+++ b/src/marketplace/config.rs
@@ -36,8 +36,10 @@ impl Config {
             });
         }
 
-        let project_dirs = ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION)
-            .ok_or_else(|| MarketplaceError::Configuration("Unable to resolve project directories".into()))?;
+        let project_dirs =
+            ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION).ok_or_else(|| {
+                MarketplaceError::Configuration("Unable to resolve project directories".into())
+            })?;
 
         Ok(Self {
             cache_dir: project_dirs.cache_dir().to_path_buf(),

--- a/src/marketplace/error.rs
+++ b/src/marketplace/error.rs
@@ -26,8 +26,11 @@ pub enum MarketplaceError {
     #[error("network request failed: {0}")]
     Network(String),
 
-    #[error("rate limit active for source {source}: resets at {reset_at}")]
-    RateLimited { source: String, reset_at: String },
+    #[error("rate limit active for source {source_slug}{}", DisplayReset(reset_at))]
+    RateLimited {
+        source_slug: String,
+        reset_at: Option<String>,
+    },
 
     #[error("manifest invalid for repository {repository}: {reason}")]
     InvalidManifest { repository: String, reason: String },
@@ -55,5 +58,16 @@ impl MarketplaceError {
 
     pub fn configuration(msg: impl Into<String>) -> Self {
         Self::Configuration(msg.into())
+    }
+}
+
+struct DisplayReset<'a>(&'a Option<String>);
+
+impl<'a> std::fmt::Display for DisplayReset<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            Some(value) => write!(f, " (resets at {value})"),
+            None => Ok(()),
+        }
     }
 }

--- a/src/marketplace/models/domain.rs
+++ b/src/marketplace/models/domain.rs
@@ -73,6 +73,24 @@ pub struct MarketplaceSource {
     pub poll_interval_hours: Option<u64>,
 }
 
+impl MarketplaceSource {
+    pub fn default_curated(url: Url) -> Self {
+        Self {
+            slug: "athola".to_string(),
+            display_name: "Athola Default".to_string(),
+            url,
+            source_type: SourceType::GithubRepo,
+            default: true,
+            enabled: true,
+            requires_auth: false,
+            last_synced_at: None,
+            last_sync_status: SyncStatus::Idle,
+            etag: None,
+            poll_interval_hours: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SourceType {
     GithubRepo,

--- a/src/marketplace/services/catalog.rs
+++ b/src/marketplace/services/catalog.rs
@@ -1,8 +1,6 @@
 //! Catalog service responsible for aggregating extensions across sources,
 //! applying filtering, and translating results for CLI/API consumers.
 
-use std::time::Duration;
-
 use anyhow::Result;
 use serde::Serialize;
 
@@ -47,7 +45,11 @@ pub struct ListResponse {
 }
 
 impl CatalogService {
-    pub fn new(fetcher: SourceFetcher, prefs: PreferencesService, sources: Vec<MarketplaceSource>) -> Self {
+    pub fn new(
+        fetcher: SourceFetcher,
+        prefs: PreferencesService,
+        sources: Vec<MarketplaceSource>,
+    ) -> Self {
         Self {
             fetcher,
             prefs,
@@ -66,7 +68,10 @@ impl CatalogService {
         for source in self.sources.iter().filter(|src| src.enabled) {
             match self.fetch_source(source, request.prefetch_filter).await {
                 Ok(extensions) => entries.extend(make_entries(source, extensions)),
-                Err(SourceWarning::Cached { extensions, warning }) => {
+                Err(SourceWarning::Cached {
+                    extensions,
+                    warning,
+                }) => {
                     warnings.push(warning);
                     entries.extend(make_entries(source, extensions));
                 }
@@ -89,40 +94,47 @@ impl CatalogService {
         match self.fetcher.sync_source(source).await {
             Ok(list) => Ok(list),
             Err(err) => match err {
-                MarketplaceError::RateLimited { source: slug, reset_at } => {
-                    let mut message = format!("Source {slug} is rate limited");
+                MarketplaceError::RateLimited {
+                    source_slug,
+                    reset_at,
+                } => {
+                    let mut warning = format!("Source {source_slug} is rate limited");
                     if let Some(ts) = reset_at {
-                        message.push_str(&format!(" (resets at {ts})"));
+                        warning.push_str(&format!(" (resets at {ts})"));
                     }
-                    let cached = self
-                        .fetcher
-                        .cached_extensions(&source.slug)
-                        .map_err(|cache_err| SourceWarning::Fatal {
-                            warning: format!(
-                                "{}; additionally failed to read cache: {}",
-                                message, cache_err
-                            ),
-                        })?;
-                    cached.map_or_else(
-                        || Err(SourceWarning::Fatal { warning: message }),
-                        |data| Err(SourceWarning::Cached { extensions: data, warning: message }),
-                    )
+                    let cached =
+                        self.fetcher
+                            .cached_extensions(&source.slug)
+                            .map_err(|cache_err| SourceWarning::Fatal {
+                                warning: format!(
+                                    "{warning}; additionally failed to read cache: {cache_err}"
+                                ),
+                            })?;
+                    if let Some(data) = cached {
+                        return Err(SourceWarning::Cached {
+                            extensions: data,
+                            warning,
+                        });
+                    }
+                    Err(SourceWarning::Fatal { warning })
                 }
                 MarketplaceError::Network(detail) => {
-                    let message = format!("Network error for {}: {}", source.slug, detail);
-                    let cached = self
-                        .fetcher
-                        .cached_extensions(&source.slug)
-                        .map_err(|cache_err| SourceWarning::Fatal {
-                            warning: format!(
-                                "{}; additionally failed to read cache: {}",
-                                message, cache_err
-                            ),
-                        })?;
-                    cached.map_or_else(
-                        || Err(SourceWarning::Fatal { warning: message }),
-                        |data| Err(SourceWarning::Cached { extensions: data, warning: message }),
-                    )
+                    let warning = format!("Network error for {}: {}", source.slug, detail);
+                    let cached =
+                        self.fetcher
+                            .cached_extensions(&source.slug)
+                            .map_err(|cache_err| SourceWarning::Fatal {
+                                warning: format!(
+                                    "{warning}; additionally failed to read cache: {cache_err}"
+                                ),
+                            })?;
+                    if let Some(data) = cached {
+                        return Err(SourceWarning::Cached {
+                            extensions: data,
+                            warning,
+                        });
+                    }
+                    Err(SourceWarning::Fatal { warning })
                 }
                 other => Err(SourceWarning::Fatal {
                     warning: other.to_string(),
@@ -157,9 +169,12 @@ fn filter_entries(entries: Vec<ListEntry>, request: &ListRequest<'_>) -> Vec<Lis
                 }
             }
             if let Some(source_filter) = &source {
-                if entry.source.to_lowercase() != *source_filter
-                    && !entry.namespace.to_lowercase().starts_with(source_filter)
-                {
+                let slug_matches = entry.source.to_lowercase() == *source_filter;
+                let namespace_matches = entry
+                    .namespace
+                    .to_lowercase()
+                    .starts_with(&format!("{source_filter}/"));
+                if !slug_matches && !namespace_matches {
                     return false;
                 }
             }
@@ -197,8 +212,13 @@ fn make_entries(source: &MarketplaceSource, extensions: Vec<Extension>) -> Vec<L
 }
 
 enum SourceWarning {
-    Cached { extensions: Vec<Extension>, warning: String },
-    Fatal { warning: String },
+    Cached {
+        extensions: Vec<Extension>,
+        warning: String,
+    },
+    Fatal {
+        warning: String,
+    },
 }
 
 pub fn default_preferences() -> PreferencesService {
@@ -211,9 +231,13 @@ pub fn default_preferences() -> PreferencesService {
 }
 
 pub fn default_sources() -> Vec<MarketplaceSource> {
-    let base = std::env::var("GEMINI_MARKETPLACE_SOURCE_URL")
-        .unwrap_or_else(|_| "https://raw.githubusercontent.com/athola/gemini-marketplace/main/index.json".to_string());
-    let url = base.parse().unwrap_or_else(|_| "https://raw.githubusercontent.com/athola/gemini-marketplace/main/index.json".parse().unwrap());
+    let base = std::env::var("GEMINI_MARKETPLACE_SOURCE_URL").unwrap_or_else(|_| {
+        "https://raw.githubusercontent.com/athola/gemini-marketplace/main/index.json".to_string()
+    });
+    let url = base.parse().unwrap_or_else(|_| {
+        "https://raw.githubusercontent.com/athola/gemini-marketplace/main/index.json"
+            .parse()
+            .unwrap()
+    });
     vec![MarketplaceSource::default_curated(url)]
 }
-*** End Patch

--- a/src/marketplace/services/catalog.rs
+++ b/src/marketplace/services/catalog.rs
@@ -1,15 +1,219 @@
-//! Placeholder catalog service.
+//! Catalog service responsible for aggregating extensions across sources,
+//! applying filtering, and translating results for CLI/API consumers.
+
+use std::time::Duration;
 
 use anyhow::Result;
+use serde::Serialize;
 
-pub struct CatalogService;
+use crate::marketplace::error::MarketplaceError;
+use crate::marketplace::models::domain::{
+    Extension, InstallStatus, MarketplaceSource, OutputFormat, SearchMode,
+};
+use crate::marketplace::services::preferences::PreferencesService;
+use crate::marketplace::services::source_fetcher::SourceFetcher;
+
+pub struct CatalogService {
+    fetcher: SourceFetcher,
+    prefs: PreferencesService,
+    sources: Vec<MarketplaceSource>,
+}
+
+#[derive(Debug, Default)]
+pub struct ListRequest<'a> {
+    pub search: Option<&'a str>,
+    pub category: Option<&'a str>,
+    pub source: Option<&'a str>,
+    pub installed_only: bool,
+    pub prefetch_filter: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListEntry {
+    pub namespace: String,
+    pub display_name: String,
+    pub description: String,
+    pub version: String,
+    pub source: String,
+    pub installed: bool,
+    pub categories: Vec<String>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct ListResponse {
+    pub entries: Vec<ListEntry>,
+    pub warnings: Vec<String>,
+}
 
 impl CatalogService {
-    pub fn new() -> Self {
-        Self
+    pub fn new(fetcher: SourceFetcher, prefs: PreferencesService, sources: Vec<MarketplaceSource>) -> Self {
+        Self {
+            fetcher,
+            prefs,
+            sources,
+        }
     }
 
-    pub fn list_extensions(&self) -> Result<()> {
-        anyhow::bail!("list_extensions not yet implemented");
+    pub fn preferences(&self) -> &PreferencesService {
+        &self.prefs
+    }
+
+    pub async fn list(&self, request: &ListRequest<'_>) -> Result<ListResponse> {
+        let mut warnings = Vec::new();
+        let mut entries = Vec::new();
+
+        for source in self.sources.iter().filter(|src| src.enabled) {
+            match self.fetch_source(source, request.prefetch_filter).await {
+                Ok(extensions) => entries.extend(make_entries(source, extensions)),
+                Err(SourceWarning::Cached { extensions, warning }) => {
+                    warnings.push(warning);
+                    entries.extend(make_entries(source, extensions));
+                }
+                Err(SourceWarning::Fatal { warning }) => warnings.push(warning),
+            }
+        }
+
+        let filtered = filter_entries(entries, request);
+        Ok(ListResponse {
+            entries: filtered,
+            warnings,
+        })
+    }
+
+    async fn fetch_source(
+        &self,
+        source: &MarketplaceSource,
+        _prefetch_filter: bool,
+    ) -> Result<Vec<Extension>, SourceWarning> {
+        match self.fetcher.sync_source(source).await {
+            Ok(list) => Ok(list),
+            Err(err) => match err {
+                MarketplaceError::RateLimited { source: slug, reset_at } => {
+                    let mut message = format!("Source {slug} is rate limited");
+                    if let Some(ts) = reset_at {
+                        message.push_str(&format!(" (resets at {ts})"));
+                    }
+                    let cached = self
+                        .fetcher
+                        .cached_extensions(&source.slug)
+                        .map_err(|cache_err| SourceWarning::Fatal {
+                            warning: format!(
+                                "{}; additionally failed to read cache: {}",
+                                message, cache_err
+                            ),
+                        })?;
+                    cached.map_or_else(
+                        || Err(SourceWarning::Fatal { warning: message }),
+                        |data| Err(SourceWarning::Cached { extensions: data, warning: message }),
+                    )
+                }
+                MarketplaceError::Network(detail) => {
+                    let message = format!("Network error for {}: {}", source.slug, detail);
+                    let cached = self
+                        .fetcher
+                        .cached_extensions(&source.slug)
+                        .map_err(|cache_err| SourceWarning::Fatal {
+                            warning: format!(
+                                "{}; additionally failed to read cache: {}",
+                                message, cache_err
+                            ),
+                        })?;
+                    cached.map_or_else(
+                        || Err(SourceWarning::Fatal { warning: message }),
+                        |data| Err(SourceWarning::Cached { extensions: data, warning: message }),
+                    )
+                }
+                other => Err(SourceWarning::Fatal {
+                    warning: other.to_string(),
+                }),
+            },
+        }
     }
 }
+
+fn filter_entries(entries: Vec<ListEntry>, request: &ListRequest<'_>) -> Vec<ListEntry> {
+    let search = request.search.map(|s| s.to_lowercase());
+    let category = request.category.map(|c| c.to_lowercase());
+    let source = request.source.map(|s| s.to_lowercase());
+
+    let mut filtered: Vec<ListEntry> = entries
+        .into_iter()
+        .filter(|entry| {
+            if let Some(search) = &search {
+                let name = entry.display_name.to_lowercase();
+                let description = entry.description.to_lowercase();
+                if !name.contains(search) && !description.contains(search) {
+                    return false;
+                }
+            }
+            if let Some(category) = &category {
+                if !entry
+                    .categories
+                    .iter()
+                    .any(|c| c.to_lowercase() == *category)
+                {
+                    return false;
+                }
+            }
+            if let Some(source_filter) = &source {
+                if entry.source.to_lowercase() != *source_filter
+                    && !entry.namespace.to_lowercase().starts_with(source_filter)
+                {
+                    return false;
+                }
+            }
+            if request.installed_only && !entry.installed {
+                return false;
+            }
+            true
+        })
+        .collect();
+
+    filtered.sort_by(|a, b| a.namespace.cmp(&b.namespace));
+    filtered
+}
+
+fn make_entries(source: &MarketplaceSource, extensions: Vec<Extension>) -> Vec<ListEntry> {
+    extensions
+        .into_iter()
+        .map(|ext| {
+            let installed = matches!(
+                ext.install_status,
+                InstallStatus::Installed { .. } | InstallStatus::UpdateAvailable { .. }
+            );
+            ListEntry {
+                namespace: ext.id.0,
+                display_name: ext.display_name,
+                description: ext.summary,
+                version: ext.version.to_string(),
+                source: source.slug.clone(),
+                installed,
+                categories: ext.categories,
+                tags: ext.tags,
+            }
+        })
+        .collect()
+}
+
+enum SourceWarning {
+    Cached { extensions: Vec<Extension>, warning: String },
+    Fatal { warning: String },
+}
+
+pub fn default_preferences() -> PreferencesService {
+    PreferencesService::new(crate::marketplace::models::domain::UserPreferences {
+        cache_ttl_hours: 24,
+        auto_refresh_on_launch: false,
+        search_mode: SearchMode::LocalFilter,
+        output_format: OutputFormat::Table,
+    })
+}
+
+pub fn default_sources() -> Vec<MarketplaceSource> {
+    let base = std::env::var("GEMINI_MARKETPLACE_SOURCE_URL")
+        .unwrap_or_else(|_| "https://raw.githubusercontent.com/athola/gemini-marketplace/main/index.json".to_string());
+    let url = base.parse().unwrap_or_else(|_| "https://raw.githubusercontent.com/athola/gemini-marketplace/main/index.json".parse().unwrap());
+    vec![MarketplaceSource::default_curated(url)]
+}
+*** End Patch

--- a/src/marketplace/services/preferences.rs
+++ b/src/marketplace/services/preferences.rs
@@ -1,7 +1,8 @@
 //! Preferences service handles user-configurable settings like cache TTL.
 
-use crate::marketplace::models::domain::UserPreferences;
+use crate::marketplace::models::domain::{OutputFormat, SearchMode, UserPreferences};
 
+#[derive(Clone)]
 pub struct PreferencesService {
     prefs: UserPreferences,
 }
@@ -15,7 +16,18 @@ impl PreferencesService {
         self.prefs.cache_ttl_hours
     }
 
-    #[allow(dead_code)]
+    pub fn search_mode(&self) -> SearchMode {
+        self.prefs.search_mode.clone()
+    }
+
+    pub fn output_format(&self) -> OutputFormat {
+        self.prefs.output_format.clone()
+    }
+
+    pub fn auto_refresh_on_launch(&self) -> bool {
+        self.prefs.auto_refresh_on_launch
+    }
+
     pub fn update(&mut self, prefs: UserPreferences) {
         self.prefs = prefs;
     }

--- a/src/marketplace/services/refresh.rs
+++ b/src/marketplace/services/refresh.rs
@@ -13,3 +13,9 @@ impl RefreshService {
         anyhow::bail!("queue_refresh not yet implemented");
     }
 }
+
+impl Default for RefreshService {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/marketplace/services/source_fetcher.rs
+++ b/src/marketplace/services/source_fetcher.rs
@@ -3,8 +3,10 @@
 
 use std::time::{Duration, SystemTime};
 
-use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, ETAG, USER_AGENT};
 use reqwest::Client;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use tokio::time::sleep;
 
 use crate::marketplace::cache::store::CacheStore;
@@ -38,9 +40,9 @@ impl SourceFetcher {
 
     pub async fn sync_source(&self, source: &MarketplaceSource) -> Result<Vec<Extension>> {
         let ttl = Duration::from_secs((self.prefs.cache_ttl_hours() as u64) * 3600);
-        if let Some(cache_entry) = self.cache.load(&source.slug)? {
-            if cache_entry.expires_at > SystemTime::now() {
-                // TODO: map cache_entry to denormalized extension list
+        if let Some(snapshot) = self.cache.load(&source.slug)? {
+            if snapshot.entry.expires_at > SystemTime::now() {
+                return Ok(snapshot.extensions);
             }
         }
 
@@ -71,12 +73,23 @@ impl SourceFetcher {
             }
         }
 
+        let etag = response
+            .headers()
+            .get(ETAG)
+            .and_then(|value| value.to_str().ok())
+            .map(|s| s.to_string());
+
         let body = response
             .text()
             .await
             .map_err(|err| MarketplaceError::Network(format!("read body failed: {err}")))?;
-        // TODO: parse repository listing format into manifest URLs
-        let manifest_urls: Vec<String> = vec![];
+
+        let manifest_urls = CatalogBody::parse(&body).map_err(|err| {
+            MarketplaceError::Configuration(format!(
+                "Invalid catalog for {}: {err}",
+                source.slug
+            ))
+        })?;
         let mut extensions = Vec::new();
         for manifest_url in manifest_urls {
             let manifest_response =
@@ -110,27 +123,37 @@ impl SourceFetcher {
             let (manifest, validation) =
                 ExtensionManifest::from_str(&manifest_body, &manifest_url)?;
             if !validation.is_clean() {
-                return Err(MarketplaceError::InvalidManifest {
-                    repository: manifest_url,
-                    reason: format!(
-                        "warnings detected: {}",
-                        validation
-                            .warnings
-                            .iter()
-                            .map(|w| format!("{}: {}", w.field, w.message))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    ),
-                });
+                for warning in &validation.warnings {
+                    eprintln!(
+                        "Manifest warning [{}]: {} ({})",
+                        source.slug, warning.field, warning.message
+                    );
+                }
             }
-            extensions.push(Self::to_extension(source, &manifest));
+            let checksum = format!("{:x}", Sha256::digest(manifest_body.as_bytes()));
+            extensions.push(Self::to_extension(source, &manifest, ttl, checksum));
         }
 
-        self.cache.save(&source.slug, &extensions, None, ttl)?;
+        self.cache.save(&source.slug, &extensions, etag, ttl)?;
         Ok(extensions)
     }
 
-    fn to_extension(source: &MarketplaceSource, manifest: &ExtensionManifest) -> Extension {
+    pub fn cached_extensions(&self, source_slug: &str) -> Result<Option<Vec<Extension>>> {
+        Ok(self
+            .cache
+            .load(source_slug)?
+            .map(|snapshot| snapshot.extensions))
+    }
+
+    fn to_extension(
+        source: &MarketplaceSource,
+        manifest: &ExtensionManifest,
+        ttl: Duration,
+        checksum: String,
+    ) -> Extension {
+        let expires_at = SystemTime::now()
+            .checked_add(ttl)
+            .unwrap_or_else(|| SystemTime::now());
         Extension {
             id: ExtensionId::new(&source.slug, &manifest.name),
             source_slug: source.slug.clone(),
@@ -150,10 +173,10 @@ impl SourceFetcher {
             tags: manifest.tags.clone(),
             compatibility: manifest.compatibility.clone(),
             install_status: InstallStatus::Unknown,
-            manifest_checksum: String::new(),
+            manifest_checksum: checksum,
             readme_excerpt: manifest.readme.clone(),
             last_synced_at: Some(SystemTime::now()),
-            cache_expires_at: None,
+            cache_expires_at: Some(expires_at),
         }
     }
 
@@ -186,5 +209,47 @@ impl SourceFetcher {
 
     fn check_rate_limited(response: &reqwest::Response) -> bool {
         response.status().as_u16() == 403
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum CatalogBody {
+    Array(Vec<String>),
+    Object { manifests: Vec<String> },
+}
+
+impl CatalogBody {
+    fn parse(body: &str) -> Result<Vec<String>> {
+        let parsed: CatalogBody = serde_json::from_str(body).map_err(|err| {
+            MarketplaceError::Configuration(format!("invalid catalog payload: {err}"))
+        })?;
+        Ok(match parsed {
+            CatalogBody::Array(urls) => urls,
+            CatalogBody::Object { manifests } => manifests,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_array_catalog() {
+        let urls = CatalogBody::parse("[\"a.json\", \"b.json\"]").unwrap();
+        assert_eq!(urls.len(), 2);
+    }
+
+    #[test]
+    fn parses_object_catalog() {
+        let urls = CatalogBody::parse("{\"manifests\":[\"a.json\"]}").unwrap();
+        assert_eq!(urls, vec!["a.json".to_string()]);
+    }
+
+    #[test]
+    fn invalid_payload_returns_error() {
+        let err = CatalogBody::parse("not json").unwrap_err();
+        assert!(err.to_string().contains("invalid catalog payload"));
     }
 }

--- a/src/marketplace/services/source_fetcher.rs
+++ b/src/marketplace/services/source_fetcher.rs
@@ -64,11 +64,10 @@ impl SourceFetcher {
         if response.status().as_u16() == 403 {
             if let Some(window) = Self::extract_rate_limit(&source.slug, &response) {
                 return Err(MarketplaceError::RateLimited {
-                    source: source.slug.clone(),
+                    source_slug: source.slug.clone(),
                     reset_at: window
                         .reset_at
-                        .map(|instant| humantime::format_rfc3339_seconds(instant).to_string())
-                        .unwrap_or_else(|| "unknown".into()),
+                        .map(|instant| humantime::format_rfc3339_seconds(instant).to_string()),
                 });
             }
         }
@@ -85,10 +84,7 @@ impl SourceFetcher {
             .map_err(|err| MarketplaceError::Network(format!("read body failed: {err}")))?;
 
         let manifest_urls = CatalogBody::parse(&body).map_err(|err| {
-            MarketplaceError::Configuration(format!(
-                "Invalid catalog for {}: {err}",
-                source.slug
-            ))
+            MarketplaceError::Configuration(format!("Invalid catalog for {}: {err}", source.slug))
         })?;
         let mut extensions = Vec::new();
         for manifest_url in manifest_urls {
@@ -110,11 +106,10 @@ impl SourceFetcher {
                     });
                 sleep(Duration::from_secs(5)).await;
                 return Err(MarketplaceError::RateLimited {
-                    source: source.slug.clone(),
+                    source_slug: source.slug.clone(),
                     reset_at: window
                         .reset_at
-                        .map(|instant| humantime::format_rfc3339_seconds(instant).to_string())
-                        .unwrap_or_else(|| "unknown".into()),
+                        .map(|instant| humantime::format_rfc3339_seconds(instant).to_string()),
                 });
             }
             let manifest_body = manifest_response.text().await.map_err(|err| {
@@ -153,7 +148,7 @@ impl SourceFetcher {
     ) -> Extension {
         let expires_at = SystemTime::now()
             .checked_add(ttl)
-            .unwrap_or_else(|| SystemTime::now());
+            .unwrap_or_else(SystemTime::now);
         Extension {
             id: ExtensionId::new(&source.slug, &manifest.name),
             source_slug: source.slug.clone(),

--- a/src/marketplace/services/sources.rs
+++ b/src/marketplace/services/sources.rs
@@ -13,3 +13,9 @@ impl SourcesService {
         anyhow::bail!("add_source not yet implemented");
     }
 }
+
+impl Default for SourcesService {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tests/integration/api_server.rs
+++ b/tests/integration/api_server.rs
@@ -1,0 +1,37 @@
+use std::net::TcpListener;
+
+use axum::Server;
+use gemini_marketplace::marketplace::api::server::ApiServer;
+use tokio::task::JoinHandle;
+
+async fn spawn_server() -> (String, JoinHandle<()>) {
+    let server = ApiServer::new();
+    let router = server.router();
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let addr = listener.local_addr().expect("address");
+    let handle = tokio::spawn(async move {
+        Server::from_tcp(listener)
+            .expect("server")
+            .serve(router.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    (format!("http://{addr}"), handle)
+}
+
+#[tokio::test]
+async fn status_endpoint_returns_not_implemented() {
+    let (base, handle) = spawn_server().await;
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("{}/marketplace/status", base))
+        .send()
+        .await
+        .expect("request succeeds");
+
+    assert_eq!(response.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
+
+    handle.abort();
+}

--- a/tests/integration/cache_store.rs
+++ b/tests/integration/cache_store.rs
@@ -1,0 +1,59 @@
+use std::env;
+use std::time::{Duration, SystemTime};
+
+use gemini_marketplace::marketplace::cache::store::CacheStore;
+use gemini_marketplace::marketplace::config::Config;
+use gemini_marketplace::marketplace::models::domain::{Extension, ExtensionId, InstallStatus};
+use semver::Version;
+use tempfile::tempdir;
+use url::Url;
+
+fn sample_extension(source_slug: &str, slug: &str) -> Extension {
+    Extension {
+        id: ExtensionId::new(source_slug, slug),
+        source_slug: source_slug.to_string(),
+        extension_slug: slug.to_string(),
+        display_name: "Sample Extension".to_string(),
+        summary: "Summary".to_string(),
+        repository_url: Url::parse("https://github.com/example/demo").unwrap(),
+        homepage_url: None,
+        documentation_url: None,
+        version: Version::parse("1.0.0").unwrap(),
+        author: "Example".to_string(),
+        license: Some("MIT".to_string()),
+        categories: vec!["cli-tools".to_string()],
+        tags: vec!["utility".to_string()],
+        compatibility: vec!["cli>=1.0".to_string()],
+        install_status: InstallStatus::NotInstalled,
+        manifest_checksum: "abc123".to_string(),
+        readme_excerpt: None,
+        last_synced_at: Some(SystemTime::now()),
+        cache_expires_at: None,
+    }
+}
+
+#[test]
+fn cache_store_persists_and_loads_entries() -> anyhow::Result<()> {
+    let temp = tempdir()?;
+    env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
+    let config = Config::new()?;
+    config.ensure_dirs()?;
+
+    let store = CacheStore::new(&config)?;
+    let extensions = vec![sample_extension("athola", "marketplace")];
+
+    store.save("athola", &extensions, Some("etag-123".into()), Duration::from_secs(3600))?;
+
+    let snapshot = store.load("athola")?.expect("cache entry exists");
+    assert_eq!(snapshot.entry.source_slug, "athola");
+    assert!(snapshot.entry.expires_at > snapshot.entry.fetched_at);
+    assert_eq!(snapshot.entry.etag.as_deref(), Some("etag-123"));
+    assert_eq!(snapshot.entry.extension_ids.len(), 1);
+    assert_eq!(snapshot.extensions.len(), 1);
+
+    store.invalidate("athola")?;
+    assert!(store.load("athola")?.is_none());
+
+    env::remove_var("GEMINI_MARKETPLACE_HOME");
+    Ok(())
+}

--- a/tests/integration/cli_parse.rs
+++ b/tests/integration/cli_parse.rs
@@ -1,0 +1,15 @@
+use assert_cmd::Command;
+
+#[test]
+fn list_command_accepts_search_flags() {
+    let mut cmd = Command::cargo_bin("gemini-marketplace").expect("binary exists");
+    cmd.args(["list", "--search", "analytics", "--json"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn sources_subcommand_structure_parses() {
+    let mut cmd = Command::cargo_bin("gemini-marketplace").expect("binary exists");
+    cmd.args(["sources", "list", "--json"]).assert().success();
+}

--- a/tests/integration/list_cli.rs
+++ b/tests/integration/list_cli.rs
@@ -1,0 +1,49 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+use tempfile::tempdir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cli_list_outputs_json() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    let manifests = vec![format!("{}/manifests/tool.json", server.uri())];
+    Mock::given(method("GET")).and(path("/index.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&manifests))
+        .mount(&server)
+        .await;
+
+    let manifest = serde_json::json!({
+        "name": "tool",
+        "displayName": "Tool",
+        "description": "Helpful tool",
+        "repository": "https://github.com/example/tool",
+        "version": "1.0.0",
+        "author": "Example",
+        "categories": ["utility"],
+        "tags": ["tool"],
+        "compatibility": ["cli>=1.0"]
+    });
+    Mock::given(method("GET")).and(path("/manifests/tool.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&manifest))
+        .mount(&server)
+        .await;
+
+    let temp = tempdir()?;
+    std::env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
+    std::env::set_var(
+        "GEMINI_MARKETPLACE_SOURCE_URL",
+        format!("{}/index.json", server.uri()),
+    );
+
+    Command::cargo_bin("gemini-marketplace")?
+        .args(["list", "--json"])
+        .assert()
+        .success()
+        .stdout(contains("\"namespace\": \"athola/tool\""));
+
+    server.stop().await;
+    std::env::remove_var("GEMINI_MARKETPLACE_HOME");
+    std::env::remove_var("GEMINI_MARKETPLACE_SOURCE_URL");
+    Ok(())
+}

--- a/tests/integration/list_cli.rs
+++ b/tests/integration/list_cli.rs
@@ -1,40 +1,69 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
 use assert_cmd::Command;
+use axum::{Router, routing::get, Json};
 use predicates::str::contains;
 use tempfile::tempdir;
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use url::Url;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn spawn(app: Router) -> anyhow::Result<(SocketAddr, JoinHandle<()>)> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let handle = tokio::spawn(async move {
+        axum::Server::from_tcp(listener)
+            .unwrap()
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+    Ok((addr, handle))
+}
+
+#[tokio::test]
 async fn cli_list_outputs_json() -> anyhow::Result<()> {
-    let server = MockServer::start().await;
-    let manifests = vec![format!("{}/manifests/tool.json", server.uri())];
-    Mock::given(method("GET")).and(path("/index.json"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&manifests))
-        .mount(&server)
-        .await;
-
-    let manifest = serde_json::json!({
+    let manifests = Arc::new(vec![
+        "http://placeholder/manifests/tool.json".to_string(),
+    ]);
+    let manifest_body = Arc::new(serde_json::json!({
         "name": "tool",
         "displayName": "Tool",
         "description": "Helpful tool",
         "repository": "https://github.com/example/tool",
         "version": "1.0.0",
         "author": "Example",
-        "categories": ["utility"],
+        "categories": ["Utility"],
         "tags": ["tool"],
         "compatibility": ["cli>=1.0"]
-    });
-    Mock::given(method("GET")).and(path("/manifests/tool.json"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&manifest))
-        .mount(&server)
-        .await;
+    }));
+
+    let manifests_clone = manifests.clone();
+    let manifest_clone = manifest_body.clone();
+
+    let app = Router::new()
+        .route(
+            "/index.json",
+            get(move || {
+                let data = manifests_clone.clone();
+                async move { Json((*data).clone()) }
+            }),
+        )
+        .route(
+            "/manifests/tool.json",
+            get(move || {
+                let data = manifest_clone.clone();
+                async move { Json((*data).clone()) }
+            }),
+        );
+
+    let (addr, handle) = spawn(app).await?;
+    let base = format!("http://{addr}");
 
     let temp = tempdir()?;
     std::env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
-    std::env::set_var(
-        "GEMINI_MARKETPLACE_SOURCE_URL",
-        format!("{}/index.json", server.uri()),
-    );
+    std::env::set_var("GEMINI_MARKETPLACE_SOURCE_URL", format!("{base}/index.json"));
 
     Command::cargo_bin("gemini-marketplace")?
         .args(["list", "--json"])
@@ -42,7 +71,7 @@ async fn cli_list_outputs_json() -> anyhow::Result<()> {
         .success()
         .stdout(contains("\"namespace\": \"athola/tool\""));
 
-    server.stop().await;
+    handle.abort();
     std::env::remove_var("GEMINI_MARKETPLACE_HOME");
     std::env::remove_var("GEMINI_MARKETPLACE_SOURCE_URL");
     Ok(())

--- a/tests/integration/list_extensions.rs
+++ b/tests/integration/list_extensions.rs
@@ -1,0 +1,201 @@
+use std::env;
+
+use gemini_marketplace::marketplace::config::Config;
+use gemini_marketplace::marketplace::models::domain::{MarketplaceSource, OutputFormat, SearchMode, UserPreferences};
+use gemini_marketplace::marketplace::services::catalog::{CatalogService, ListRequest};
+use gemini_marketplace::marketplace::services::preferences::PreferencesService;
+use gemini_marketplace::marketplace::services::source_fetcher::SourceFetcher;
+use tempfile::tempdir;
+use tokio::runtime::Runtime;
+use url::Url;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn runtime() -> Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+fn prefs() -> PreferencesService {
+    PreferencesService::new(UserPreferences {
+        cache_ttl_hours: 1,
+        auto_refresh_on_launch: false,
+        search_mode: SearchMode::LocalFilter,
+        output_format: OutputFormat::Table,
+    })
+}
+
+fn source(url: Url) -> MarketplaceSource {
+    MarketplaceSource::default_curated(url)
+}
+
+#[test]
+fn catalog_service_lists_and_filters_extensions() -> anyhow::Result<()> {
+    let rt = runtime();
+    rt.block_on(async move {
+        let server = MockServer::start().await;
+
+        let manifests = vec![
+            format!("{}/manifests/analytics.json", server.uri()),
+            format!("{}/manifests/storage.json", server.uri()),
+        ];
+        Mock::given(method("GET"))
+            .and(path("/index.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&manifests))
+            .mount(&server)
+            .await;
+
+        let analytics_manifest = serde_json::json!({
+            "name": "analytics",
+            "displayName": "Analytics Toolkit",
+            "description": "Tools for analytics workflows",
+            "repository": "https://github.com/example/analytics",
+            "version": "1.0.0",
+            "author": "Example",
+            "categories": ["Data Science"],
+            "tags": ["analysis"],
+            "compatibility": ["cli>=1.0"]
+        });
+        let storage_manifest = serde_json::json!({
+            "name": "storage",
+            "displayName": "Storage Helper",
+            "description": "Manage storage buckets",
+            "repository": "https://github.com/example/storage",
+            "version": "2.0.0",
+            "author": "Example",
+            "categories": [" Infrastructure "],
+            "tags": ["storage"],
+            "compatibility": ["cli>=1.0"]
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/manifests/analytics.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&analytics_manifest))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/manifests/storage.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&storage_manifest))
+            .mount(&server)
+            .await;
+
+        let temp = tempdir()?;
+        env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
+        let config = Config::new()?;
+        config.ensure_dirs()?;
+
+        let preferences = prefs();
+        let fetcher = SourceFetcher::new(&config, preferences.clone())?;
+        let sources = vec![source(Url::parse(&format!("{}/index.json", server.uri()))?)];
+        let service = CatalogService::new(fetcher, preferences, sources);
+
+        let request = ListRequest {
+            search: Some("analytics"),
+            category: None,
+            source: None,
+            installed_only: false,
+            prefetch_filter: false,
+        };
+
+        let response = service.list(&request).await?;
+        assert_eq!(response.entries.len(), 1);
+        assert_eq!(response.entries[0].namespace, "athola/analytics");
+
+        let request = ListRequest {
+            search: None,
+            category: Some("infrastructure"),
+            source: None,
+            installed_only: false,
+            prefetch_filter: false,
+        };
+        let response = service.list(&request).await?;
+        assert_eq!(response.entries.len(), 1);
+        assert_eq!(response.entries[0].namespace, "athola/storage");
+
+        env::remove_var("GEMINI_MARKETPLACE_HOME");
+        server.stop().await;
+        Ok(())
+    })
+}
+
+#[test]
+fn catalog_service_returns_cached_entries_on_network_failure() -> anyhow::Result<()> {
+    let rt = runtime();
+    rt.block_on(async move {
+        let server = MockServer::start().await;
+
+        let manifests = vec![format!("{}/manifests/tool.json", server.uri())];
+        Mock::given(method("GET"))
+            .and(path("/index.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&manifests))
+            .mount(&server)
+            .await;
+
+        let manifest = serde_json::json!({
+            "name": "tool",
+            "displayName": "Tool",
+            "description": "Useful tool",
+            "repository": "https://github.com/example/tool",
+            "version": "1.0.0",
+            "author": "Example",
+            "categories": ["Utility Tools"],
+            "tags": ["tool"],
+            "compatibility": ["cli>=1.0"]
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/manifests/tool.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&manifest))
+            .mount(&server)
+            .await;
+
+        let temp = tempdir()?;
+        env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
+        let config = Config::new()?;
+        config.ensure_dirs()?;
+
+        let preferences = prefs();
+        let fetcher = SourceFetcher::new(&config, preferences.clone())?;
+        let sources = vec![source(Url::parse(&format!("{}/index.json", server.uri()))?)];
+        let service = CatalogService::new(fetcher, preferences, sources);
+
+        // Initial fetch populates the cache.
+        let response = service
+            .list(&ListRequest {
+                search: None,
+                category: None,
+                source: None,
+                installed_only: false,
+                prefetch_filter: false,
+            })
+            .await?;
+        assert_eq!(response.entries.len(), 1);
+        assert!(response.warnings.is_empty());
+
+        // Simulate subsequent network failure.
+        server.reset().await;
+        Mock::given(method("GET"))
+            .and(path("/index.json"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let response = service
+            .list(&ListRequest {
+                search: None,
+                category: None,
+                source: None,
+                installed_only: false,
+                prefetch_filter: false,
+            })
+            .await?;
+        assert_eq!(response.entries.len(), 1);
+        assert!(!response.warnings.is_empty());
+
+        env::remove_var("GEMINI_MARKETPLACE_HOME");
+        server.stop().await;
+        Ok(())
+    })
+}

--- a/tests/integration/list_extensions.rs
+++ b/tests/integration/list_extensions.rs
@@ -1,21 +1,29 @@
-use std::env;
+use std::net::SocketAddr;
+use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+
+use axum::{Router, routing::get, Json, response::IntoResponse};
+use axum::http::{StatusCode, Response};
+use serde_json::json;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use url::Url;
 
 use gemini_marketplace::marketplace::config::Config;
 use gemini_marketplace::marketplace::models::domain::{MarketplaceSource, OutputFormat, SearchMode, UserPreferences};
 use gemini_marketplace::marketplace::services::catalog::{CatalogService, ListRequest};
 use gemini_marketplace::marketplace::services::preferences::PreferencesService;
 use gemini_marketplace::marketplace::services::source_fetcher::SourceFetcher;
-use tempfile::tempdir;
-use tokio::runtime::Runtime;
-use url::Url;
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
 
-fn runtime() -> Runtime {
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .unwrap()
+async fn spawn(app: Router) -> anyhow::Result<(SocketAddr, JoinHandle<()>)> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    Ok((addr, handle))
 }
 
 fn prefs() -> PreferencesService {
@@ -31,171 +39,219 @@ fn source(url: Url) -> MarketplaceSource {
     MarketplaceSource::default_curated(url)
 }
 
-#[test]
-fn catalog_service_lists_and_filters_extensions() -> anyhow::Result<()> {
-    let rt = runtime();
-    rt.block_on(async move {
-        let server = MockServer::start().await;
+#[tokio::test]
+async fn catalog_service_lists_and_filters_extensions() -> anyhow::Result<()> {
+    let manifests = json!([
+        "http://placeholder/manifests/analytics.json",
+        "http://placeholder/manifests/storage.json",
+    ]);
+    let analytics_manifest = json!({
+        "name": "analytics",
+        "displayName": "Analytics Toolkit",
+        "description": "Tools for analytics workflows",
+        "repository": "https://github.com/example/analytics",
+        "version": "1.0.0",
+        "author": "Example",
+        "categories": ["Data Science"],
+        "tags": ["analysis"],
+        "compatibility": ["cli>=1.0"]
+    });
+    let storage_manifest = json!({
+        "name": "storage",
+        "displayName": "Storage Helper",
+        "description": "Manage storage buckets",
+        "repository": "https://github.com/example/storage",
+        "version": "2.0.0",
+        "author": "Example",
+        "categories": [" Infrastructure "],
+        "tags": ["storage"],
+        "compatibility": ["cli>=1.0"]
+    });
 
-        let manifests = vec![
-            format!("{}/manifests/analytics.json", server.uri()),
-            format!("{}/manifests/storage.json", server.uri()),
-        ];
-        Mock::given(method("GET"))
-            .and(path("/index.json"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(&manifests))
-            .mount(&server)
-            .await;
+    let manifests_clone = manifests.clone();
+    let analytics_clone = analytics_manifest.clone();
+    let storage_clone = storage_manifest.clone();
 
-        let analytics_manifest = serde_json::json!({
-            "name": "analytics",
-            "displayName": "Analytics Toolkit",
-            "description": "Tools for analytics workflows",
-            "repository": "https://github.com/example/analytics",
-            "version": "1.0.0",
-            "author": "Example",
-            "categories": ["Data Science"],
-            "tags": ["analysis"],
-            "compatibility": ["cli>=1.0"]
-        });
-        let storage_manifest = serde_json::json!({
-            "name": "storage",
-            "displayName": "Storage Helper",
-            "description": "Manage storage buckets",
-            "repository": "https://github.com/example/storage",
-            "version": "2.0.0",
-            "author": "Example",
-            "categories": [" Infrastructure "],
-            "tags": ["storage"],
-            "compatibility": ["cli>=1.0"]
-        });
+    let app = Router::new()
+        .route(
+            "/index.json",
+            get(move || {
+                let data = manifests_clone.clone();
+                async move { Json(data) }
+            }),
+        )
+        .route(
+            "/manifests/analytics.json",
+            get(move || {
+                let data = analytics_clone.clone();
+                async move { Json(data) }
+            }),
+        )
+        .route(
+            "/manifests/storage.json",
+            get(move || {
+                let data = storage_clone.clone();
+                async move { Json(data) }
+            }),
+        );
 
-        Mock::given(method("GET"))
-            .and(path("/manifests/analytics.json"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(&analytics_manifest))
-            .mount(&server)
-            .await;
-        Mock::given(method("GET"))
-            .and(path("/manifests/storage.json"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(&storage_manifest))
-            .mount(&server)
-            .await;
+    let (addr, handle) = spawn(app).await?;
+    let base_url = format!("http://{addr}");
 
-        let temp = tempdir()?;
-        env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
-        let config = Config::new()?;
-        config.ensure_dirs()?;
+    let temp = tempdir()?;
+    std::env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
+    std::env::set_var("GEMINI_MARKETPLACE_SOURCE_URL", format!("{base_url}/index.json"));
 
-        let preferences = prefs();
-        let fetcher = SourceFetcher::new(&config, preferences.clone())?;
-        let sources = vec![source(Url::parse(&format!("{}/index.json", server.uri()))?)];
-        let service = CatalogService::new(fetcher, preferences, sources);
+    let config = Config::new()?;
+    config.ensure_dirs()?;
+    let preferences = prefs();
+    let fetcher = SourceFetcher::new(&config, preferences.clone())?;
+    let sources = vec![source(Url::parse(&format!("{base_url}/index.json"))?)];
+    let service = CatalogService::new(fetcher, preferences, sources);
 
-        let request = ListRequest {
+    let response = service
+        .list(&ListRequest {
             search: Some("analytics"),
             category: None,
             source: None,
             installed_only: false,
             prefetch_filter: false,
-        };
+        })
+        .await?;
+    assert_eq!(response.entries.len(), 1);
+    assert_eq!(response.entries[0].namespace, "athola/analytics");
 
-        let response = service.list(&request).await?;
-        assert_eq!(response.entries.len(), 1);
-        assert_eq!(response.entries[0].namespace, "athola/analytics");
-
-        let request = ListRequest {
+    let response = service
+        .list(&ListRequest {
             search: None,
             category: Some("infrastructure"),
             source: None,
             installed_only: false,
             prefetch_filter: false,
-        };
-        let response = service.list(&request).await?;
-        assert_eq!(response.entries.len(), 1);
-        assert_eq!(response.entries[0].namespace, "athola/storage");
+        })
+        .await?;
+    assert_eq!(response.entries.len(), 1);
+    assert_eq!(response.entries[0].namespace, "athola/storage");
 
-        env::remove_var("GEMINI_MARKETPLACE_HOME");
-        server.stop().await;
-        Ok(())
-    })
+    let response = service
+        .list(&ListRequest {
+            search: None,
+            category: None,
+            source: Some("athola"),
+            installed_only: false,
+            prefetch_filter: false,
+        })
+        .await?;
+    assert_eq!(response.entries.len(), 1);
+    assert_eq!(response.entries[0].namespace, "athola/analytics");
+
+    let response = service
+        .list(&ListRequest {
+            search: None,
+            category: None,
+            source: Some("ath"),
+            installed_only: false,
+            prefetch_filter: false,
+        })
+        .await?;
+    assert!(response.entries.is_empty());
+
+    handle.abort();
+    std::env::remove_var("GEMINI_MARKETPLACE_HOME");
+    std::env::remove_var("GEMINI_MARKETPLACE_SOURCE_URL");
+    Ok(())
 }
 
-#[test]
-fn catalog_service_returns_cached_entries_on_network_failure() -> anyhow::Result<()> {
-    let rt = runtime();
-    rt.block_on(async move {
-        let server = MockServer::start().await;
+#[tokio::test]
+async fn catalog_service_returns_cached_entries_on_network_failure() -> anyhow::Result<()> {
+    let manifests = Arc::new(json!(["http://placeholder/manifests/tool.json"]));
+    let manifest_body = json!({
+        "name": "tool",
+        "displayName": "Tool",
+        "description": "Useful tool",
+        "repository": "https://github.com/example/tool",
+        "version": "1.0.0",
+        "author": "Example",
+        "categories": ["Utility Tools"],
+        "tags": ["tool"],
+        "compatibility": ["cli>=1.0"]
+    });
 
-        let manifests = vec![format!("{}/manifests/tool.json", server.uri())];
-        Mock::given(method("GET"))
-            .and(path("/index.json"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(&manifests))
-            .mount(&server)
-            .await;
+    let index_calls = Arc::new(AtomicUsize::new(0));
+    let index_calls_clone = index_calls.clone();
+    let manifests_clone = manifests.clone();
+    let manifest_body_clone = manifest_body.clone();
 
-        let manifest = serde_json::json!({
-            "name": "tool",
-            "displayName": "Tool",
-            "description": "Useful tool",
-            "repository": "https://github.com/example/tool",
-            "version": "1.0.0",
-            "author": "Example",
-            "categories": ["Utility Tools"],
-            "tags": ["tool"],
-            "compatibility": ["cli>=1.0"]
-        });
+    let app = Router::new()
+        .route(
+            "/index.json",
+            get(move || {
+                let manifests = manifests_clone.clone();
+                let counter = index_calls_clone.clone();
+                async move {
+                    let count = counter.fetch_add(1, Ordering::SeqCst);
+                    if count == 0 {
+                        Json((*manifests).clone()).into_response()
+                    } else {
+                        Response::builder()
+                            .status(StatusCode::INTERNAL_SERVER_ERROR)
+                            .body(axum::body::Body::empty())
+                            .unwrap()
+                            .into_response()
+                    }
+                }
+            }),
+        )
+        .route(
+            "/manifests/tool.json",
+            get(move || {
+                let manifest = manifest_body_clone.clone();
+                async move { Json(manifest) }
+            }),
+        );
 
-        Mock::given(method("GET"))
-            .and(path("/manifests/tool.json"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(&manifest))
-            .mount(&server)
-            .await;
+    let (addr, handle) = spawn(app).await?;
+    let base_url = format!("http://{addr}");
 
-        let temp = tempdir()?;
-        env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
-        let config = Config::new()?;
-        config.ensure_dirs()?;
+    let temp = tempdir()?;
+    std::env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
+    std::env::set_var("GEMINI_MARKETPLACE_SOURCE_URL", format!("{base_url}/index.json"));
 
-        let preferences = prefs();
-        let fetcher = SourceFetcher::new(&config, preferences.clone())?;
-        let sources = vec![source(Url::parse(&format!("{}/index.json", server.uri()))?)];
-        let service = CatalogService::new(fetcher, preferences, sources);
+    let config = Config::new()?;
+    config.ensure_dirs()?;
+    let preferences = prefs();
+    let fetcher = SourceFetcher::new(&config, preferences.clone())?;
+    let sources = vec![source(Url::parse(&format!("{base_url}/index.json"))?)];
+    let service = CatalogService::new(fetcher, preferences, sources);
 
-        // Initial fetch populates the cache.
-        let response = service
-            .list(&ListRequest {
-                search: None,
-                category: None,
-                source: None,
-                installed_only: false,
-                prefetch_filter: false,
-            })
-            .await?;
-        assert_eq!(response.entries.len(), 1);
-        assert!(response.warnings.is_empty());
+    // Warm cache
+    let response = service
+        .list(&ListRequest {
+            search: None,
+            category: None,
+            source: None,
+            installed_only: false,
+            prefetch_filter: false,
+        })
+        .await?;
+    assert_eq!(response.entries.len(), 1);
+    assert!(response.warnings.is_empty());
 
-        // Simulate subsequent network failure.
-        server.reset().await;
-        Mock::given(method("GET"))
-            .and(path("/index.json"))
-            .respond_with(ResponseTemplate::new(500))
-            .mount(&server)
-            .await;
+    // Subsequent call should return cached data and warning.
+    let response = service
+        .list(&ListRequest {
+            search: None,
+            category: None,
+            source: None,
+            installed_only: false,
+            prefetch_filter: false,
+        })
+        .await?;
+    assert_eq!(response.entries.len(), 1);
+    assert!(!response.warnings.is_empty());
 
-        let response = service
-            .list(&ListRequest {
-                search: None,
-                category: None,
-                source: None,
-                installed_only: false,
-                prefetch_filter: false,
-            })
-            .await?;
-        assert_eq!(response.entries.len(), 1);
-        assert!(!response.warnings.is_empty());
-
-        env::remove_var("GEMINI_MARKETPLACE_HOME");
-        server.stop().await;
-        Ok(())
-    })
+    handle.abort();
+    std::env::remove_var("GEMINI_MARKETPLACE_HOME");
+    std::env::remove_var("GEMINI_MARKETPLACE_SOURCE_URL");
+    Ok(())
 }

--- a/tests/integration/source_fetcher.rs
+++ b/tests/integration/source_fetcher.rs
@@ -1,0 +1,125 @@
+use std::env;
+use std::time::Duration;
+
+use gemini_marketplace::marketplace::config::Config;
+use gemini_marketplace::marketplace::models::domain::{MarketplaceSource, SourceType, SyncStatus, UserPreferences};
+use gemini_marketplace::marketplace::services::preferences::PreferencesService;
+use gemini_marketplace::marketplace::services::source_fetcher::SourceFetcher;
+use tempfile::tempdir;
+use tokio::time::timeout;
+use url::Url;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn default_source(url: Url) -> MarketplaceSource {
+    MarketplaceSource {
+        slug: "athola".to_string(),
+        display_name: "Athola Default".to_string(),
+        url,
+        source_type: SourceType::GithubRepo,
+        default: true,
+        enabled: true,
+        requires_auth: false,
+        last_synced_at: None,
+        last_sync_status: SyncStatus::Idle,
+        etag: None,
+        poll_interval_hours: None,
+    }
+}
+
+fn preferences(ttl_hours: u16) -> PreferencesService {
+    PreferencesService::new(UserPreferences {
+        cache_ttl_hours: ttl_hours,
+        auto_refresh_on_launch: false,
+        search_mode: gemini_marketplace::marketplace::models::domain::SearchMode::LocalFilter,
+        output_format: gemini_marketplace::marketplace::models::domain::OutputFormat::Table,
+    })
+}
+
+#[tokio::test]
+async fn sync_source_fetches_extensions_and_uses_cache() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    let manifests = vec![format!("{}/manifests/ext1.json", server.uri())];
+
+    Mock::given(method("GET"))
+        .and(path("/index.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&manifests))
+        .mount(&server)
+        .await;
+
+    let manifest_body = serde_json::json!({
+        "name": "demo",
+        "description": "Demo extension",
+        "repository": "https://github.com/example/demo",
+        "version": "1.0.0",
+        "author": "Example",
+        "categories": ["CLI"],
+        "tags": ["utility"],
+        "compatibility": ["cli>=1.0"],
+        "readme": "# Demo"
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/manifests/ext1.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&manifest_body))
+        .mount(&server)
+        .await;
+
+    let temp = tempdir()?;
+    env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
+    let config = Config::new()?;
+    config.ensure_dirs()?;
+
+    let fetcher = SourceFetcher::new(&config, preferences(24))?;
+    let mut source = default_source(Url::parse(&format!("{}/index.json", server.uri()))?);
+
+    let extensions = fetcher.sync_source(&source).await?;
+    assert_eq!(extensions.len(), 1);
+    assert_eq!(extensions[0].extension_slug, "demo");
+
+    // Clear mocks so any network call would fail.
+    server.reset().await;
+
+    // Second call should return cached data without hitting network.
+    let cached = fetcher.sync_source(&source).await?;
+    assert_eq!(cached.len(), 1);
+    assert_eq!(cached[0].extension_slug, "demo");
+
+    env::remove_var("GEMINI_MARKETPLACE_HOME");
+    Ok(())
+}
+
+#[tokio::test]
+async fn sync_source_respects_rate_limits() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/index.json"))
+        .respond_with(
+            ResponseTemplate::new(403)
+                .append_header("x-ratelimit-reset", "9999999999")
+                .append_header("x-ratelimit-remaining", "0")
+                .append_header("x-ratelimit-limit", "60"),
+        )
+        .mount(&server)
+        .await;
+
+    let temp = tempdir()?;
+    env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
+    let config = Config::new()?;
+    config.ensure_dirs()?;
+
+    let fetcher = SourceFetcher::new(&config, preferences(24))?;
+    let source = default_source(Url::parse(&format!("{}/index.json", server.uri()))?);
+
+    let err = fetcher.sync_source(&source).await.expect_err("rate limit");
+    match err {
+        gemini_marketplace::marketplace::error::MarketplaceError::RateLimited { source, .. } => {
+            assert_eq!(source, "athola");
+        }
+        other => panic!("expected RateLimited, got {:?}", other),
+    }
+
+    env::remove_var("GEMINI_MARKETPLACE_HOME");
+    Ok(())
+}

--- a/tests/integration/source_fetcher.rs
+++ b/tests/integration/source_fetcher.rs
@@ -1,125 +1,136 @@
-use std::env;
-use std::time::Duration;
+use std::net::SocketAddr;
+use axum::{Router, routing::get, Json};
+use axum::http::{StatusCode, Response};
+use axum::response::IntoResponse;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use url::Url;
 
 use gemini_marketplace::marketplace::config::Config;
-use gemini_marketplace::marketplace::models::domain::{MarketplaceSource, SourceType, SyncStatus, UserPreferences};
+use gemini_marketplace::marketplace::models::domain::{MarketplaceSource, OutputFormat, SearchMode, SyncStatus, UserPreferences};
 use gemini_marketplace::marketplace::services::preferences::PreferencesService;
 use gemini_marketplace::marketplace::services::source_fetcher::SourceFetcher;
-use tempfile::tempdir;
-use tokio::time::timeout;
-use url::Url;
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
 
-fn default_source(url: Url) -> MarketplaceSource {
-    MarketplaceSource {
-        slug: "athola".to_string(),
-        display_name: "Athola Default".to_string(),
-        url,
-        source_type: SourceType::GithubRepo,
-        default: true,
-        enabled: true,
-        requires_auth: false,
-        last_synced_at: None,
-        last_sync_status: SyncStatus::Idle,
-        etag: None,
-        poll_interval_hours: None,
-    }
+async fn spawn(app: Router) -> anyhow::Result<(SocketAddr, JoinHandle<()>)> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    Ok((addr, handle))
 }
 
-fn preferences(ttl_hours: u16) -> PreferencesService {
+fn prefs(ttl_hours: u16) -> PreferencesService {
     PreferencesService::new(UserPreferences {
         cache_ttl_hours: ttl_hours,
         auto_refresh_on_launch: false,
-        search_mode: gemini_marketplace::marketplace::models::domain::SearchMode::LocalFilter,
-        output_format: gemini_marketplace::marketplace::models::domain::OutputFormat::Table,
+        search_mode: SearchMode::LocalFilter,
+        output_format: OutputFormat::Table,
     })
+}
+
+fn default_source(url: Url) -> MarketplaceSource {
+    let mut source = MarketplaceSource::default_curated(url);
+    source.last_sync_status = SyncStatus::Idle;
+    source
 }
 
 #[tokio::test]
 async fn sync_source_fetches_extensions_and_uses_cache() -> anyhow::Result<()> {
-    let server = MockServer::start().await;
-    let manifests = vec![format!("{}/manifests/ext1.json", server.uri())];
-
-    Mock::given(method("GET"))
-        .and(path("/index.json"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&manifests))
-        .mount(&server)
-        .await;
-
+    let manifest_list = serde_json::json!(["http://placeholder/manifests/ext1.json"]);
     let manifest_body = serde_json::json!({
         "name": "demo",
         "description": "Demo extension",
         "repository": "https://github.com/example/demo",
         "version": "1.0.0",
         "author": "Example",
-        "categories": ["CLI"],
-        "tags": ["utility"],
+        "categories": ["utility"],
+        "tags": ["tool"],
         "compatibility": ["cli>=1.0"],
         "readme": "# Demo"
     });
 
-    Mock::given(method("GET"))
-        .and(path("/manifests/ext1.json"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&manifest_body))
-        .mount(&server)
-        .await;
+    let list_clone = manifest_list.clone();
+    let manifest_clone = manifest_body.clone();
+
+    let app = Router::new()
+        .route(
+            "/index.json",
+            get(move || {
+                let data = list_clone.clone();
+                async move { Json(data) }
+            }),
+        )
+        .route(
+            "/manifests/ext1.json",
+            get(move || {
+                let data = manifest_clone.clone();
+                async move { Json(data) }
+            }),
+        );
+
+    let (addr, handle) = spawn(app).await?;
+    let base = format!("http://{addr}");
 
     let temp = tempdir()?;
-    env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
+    std::env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
     let config = Config::new()?;
     config.ensure_dirs()?;
 
-    let fetcher = SourceFetcher::new(&config, preferences(24))?;
-    let mut source = default_source(Url::parse(&format!("{}/index.json", server.uri()))?);
+    let fetcher = SourceFetcher::new(&config, prefs(24))?;
+    let mut source = default_source(Url::parse(&format!("{base}/index.json"))?);
 
     let extensions = fetcher.sync_source(&source).await?;
     assert_eq!(extensions.len(), 1);
     assert_eq!(extensions[0].extension_slug, "demo");
 
-    // Clear mocks so any network call would fail.
-    server.reset().await;
-
-    // Second call should return cached data without hitting network.
+    // Drop server so subsequent calls cannot fetch new data; expect cached result.
+    handle.abort();
     let cached = fetcher.sync_source(&source).await?;
     assert_eq!(cached.len(), 1);
-    assert_eq!(cached[0].extension_slug, "demo");
 
-    env::remove_var("GEMINI_MARKETPLACE_HOME");
+    std::env::remove_var("GEMINI_MARKETPLACE_HOME");
     Ok(())
 }
 
 #[tokio::test]
 async fn sync_source_respects_rate_limits() -> anyhow::Result<()> {
-    let server = MockServer::start().await;
+    let rate_limit_app = Router::new().route(
+        "/index.json",
+        get(|| async {
+            Response::builder()
+                .status(StatusCode::FORBIDDEN)
+                .header("x-ratelimit-reset", "9999999999")
+                .header("x-ratelimit-remaining", "0")
+                .header("x-ratelimit-limit", "60")
+                .body(axum::body::Body::empty())
+                .unwrap()
+        }),
+    );
 
-    Mock::given(method("GET"))
-        .and(path("/index.json"))
-        .respond_with(
-            ResponseTemplate::new(403)
-                .append_header("x-ratelimit-reset", "9999999999")
-                .append_header("x-ratelimit-remaining", "0")
-                .append_header("x-ratelimit-limit", "60"),
-        )
-        .mount(&server)
-        .await;
+    let (addr, handle) = spawn(rate_limit_app).await?;
+    let base = format!("http://{addr}");
 
     let temp = tempdir()?;
-    env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
+    std::env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
     let config = Config::new()?;
     config.ensure_dirs()?;
 
-    let fetcher = SourceFetcher::new(&config, preferences(24))?;
-    let source = default_source(Url::parse(&format!("{}/index.json", server.uri()))?);
+    let fetcher = SourceFetcher::new(&config, prefs(24))?;
+    let source = default_source(Url::parse(&format!("{base}/index.json"))?);
 
     let err = fetcher.sync_source(&source).await.expect_err("rate limit");
     match err {
-        gemini_marketplace::marketplace::error::MarketplaceError::RateLimited { source, .. } => {
-            assert_eq!(source, "athola");
+        gemini_marketplace::marketplace::error::MarketplaceError::RateLimited { source_slug, .. } => {
+            assert_eq!(source_slug, "athola");
         }
         other => panic!("expected RateLimited, got {:?}", other),
     }
 
-    env::remove_var("GEMINI_MARKETPLACE_HOME");
+    handle.abort();
+    std::env::remove_var("GEMINI_MARKETPLACE_HOME");
     Ok(())
 }

--- a/tests/unit/config.rs
+++ b/tests/unit/config.rs
@@ -1,0 +1,44 @@
+use std::env;
+use std::path::Path;
+
+use tempfile::tempdir;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[test]
+fn config_uses_override_environment_variable() -> Result<()> {
+    let temp = tempdir()?;
+    env::set_var("GEMINI_MARKETPLACE_HOME", temp.path());
+
+    let config = gemini_marketplace::marketplace::config::Config::new()?;
+
+    assert!(config.cache_dir().starts_with(temp.path()));
+    assert!(config.config_dir().starts_with(temp.path()));
+    assert!(config.log_dir().starts_with(temp.path()));
+
+    // ensure directories are created under the override path
+    config.ensure_dirs()?;
+    assert!(config.cache_dir().is_dir());
+    assert!(config.config_dir().is_dir());
+    assert!(config.log_dir().is_dir());
+
+    env::remove_var("GEMINI_MARKETPLACE_HOME");
+    Ok(())
+}
+
+#[test]
+fn config_defaults_to_project_dirs() -> Result<()> {
+    env::remove_var("GEMINI_MARKETPLACE_HOME");
+    let config = gemini_marketplace::marketplace::config::Config::new()?;
+
+    let cache = config.cache_dir();
+    let config_dir = config.config_dir();
+    let log_dir = config.log_dir();
+
+    for path in [&cache, &config_dir, &log_dir] {
+        assert!(path.is_absolute());
+        assert!(Path::new(path).to_path_buf().components().count() > 1);
+    }
+
+    Ok(())
+}

--- a/tests/unit/domain.rs
+++ b/tests/unit/domain.rs
@@ -1,0 +1,54 @@
+use semver::Version;
+
+use url::Url;
+
+use gemini_marketplace::marketplace::models::domain::{
+    ExtensionId, InstallStatus, MarketplaceSource, SourceType, SyncStatus,
+};
+
+#[test]
+fn extension_id_formats_namespaced_identifier() {
+    let id = ExtensionId::new("athola", "marketplace");
+    assert_eq!(id.0, "athola/marketplace");
+}
+
+#[test]
+fn default_curated_source_uses_expected_defaults() {
+    let url = Url::parse("https://example.com/index.json").unwrap();
+    let source = MarketplaceSource::default_curated(url.clone());
+
+    assert_eq!(source.slug, "athola");
+    assert_eq!(source.display_name, "Athola Default");
+    assert_eq!(source.url, url);
+    assert!(source.default);
+    assert!(source.enabled);
+    assert!(!source.requires_auth);
+    matches!(source.source_type, SourceType::GithubRepo);
+    matches!(source.last_sync_status, SyncStatus::Idle);
+}
+
+#[test]
+fn install_status_transitions_allow_updates() {
+    let installed = InstallStatus::Installed {
+        version: Version::parse("1.0.0").unwrap(),
+    };
+    match installed {
+        InstallStatus::Installed { version } => assert_eq!(version, Version::parse("1.0.0").unwrap()),
+        other => panic!("expected Installed, got {:?}", other),
+    }
+
+    let update_available = InstallStatus::UpdateAvailable {
+        installed_version: Version::parse("1.0.0").unwrap(),
+        latest_version: Version::parse("1.1.0").unwrap(),
+    };
+    match update_available {
+        InstallStatus::UpdateAvailable {
+            installed_version,
+            latest_version,
+        } => {
+            assert_eq!(installed_version, Version::parse("1.0.0").unwrap());
+            assert_eq!(latest_version, Version::parse("1.1.0").unwrap());
+        }
+        other => panic!("expected UpdateAvailable, got {:?}", other),
+    }
+}

--- a/tests/unit/error.rs
+++ b/tests/unit/error.rs
@@ -1,0 +1,25 @@
+use std::io;
+use std::path::PathBuf;
+
+use gemini_marketplace::marketplace::error::MarketplaceError;
+
+#[test]
+fn io_helper_wraps_path_and_source() {
+    let err = MarketplaceError::io(PathBuf::from("/tmp/test"), io::Error::from(io::ErrorKind::NotFound));
+    match err {
+        MarketplaceError::Io { path, source } => {
+            assert_eq!(path, PathBuf::from("/tmp/test"));
+            assert_eq!(source.kind(), io::ErrorKind::NotFound);
+        }
+        other => panic!("expected Io variant, got {:?}", other),
+    }
+}
+
+#[test]
+fn configuration_helper_creates_configuration_variant() {
+    let err = MarketplaceError::configuration("missing value");
+    match err {
+        MarketplaceError::Configuration(msg) => assert_eq!(msg, "missing value"),
+        other => panic!("expected Configuration variant, got {:?}", other),
+    }
+}

--- a/tests/unit/manifest.rs
+++ b/tests/unit/manifest.rs
@@ -1,0 +1,50 @@
+use gemini_marketplace::marketplace::models::manifest::ExtensionManifest;
+
+#[test]
+fn normalizes_collections_and_records_warnings() {
+    let json = r#"{
+        "name": "demo",
+        "description": "Demo extension",
+        "repository": "https://github.com/example/demo",
+        "version": "1.2.3",
+        "author": "Example",
+        "categories": ["CLI Tools"],
+        "tags": ["Utility ", " CLI"],
+        "compatibility": ["cli>=1.0"]
+    }"#;
+
+    let (manifest, validation) = ExtensionManifest::from_str(json, "example/demo").expect("manifest parsed");
+
+    assert_eq!(manifest.categories, vec!["cli-tools"]);
+    assert_eq!(manifest.tags, vec!["utility", "cli"]);
+    assert!(validation
+        .warnings
+        .iter()
+        .any(|w| w.field == "categories" && w.message.contains("kebab-case")));
+}
+
+#[test]
+fn missing_required_fields_emit_warnings() {
+    let json = r#"{
+        "name": "",
+        "description": "",
+        "repository": "https://github.com/example/demo",
+        "version": "1.2.3"
+    }"#;
+
+    let (_manifest, validation) = ExtensionManifest::from_str(json, "example/demo").expect("manifest parsed");
+
+    let fields: Vec<_> = validation.warnings.iter().map(|w| w.field.as_str()).collect();
+    assert!(fields.contains(&"name"));
+    assert!(fields.contains(&"description"));
+    assert!(fields.contains(&"author"));
+    assert!(fields.contains(&"categories"));
+}
+
+#[test]
+fn invalid_json_returns_error() {
+    let json = "{ invalid";
+    let err = ExtensionManifest::from_str(json, "example/demo").expect_err("should fail");
+    let message = format!("{}", err);
+    assert!(message.contains("invalid JSON"));
+}

--- a/tests/unit/preferences.rs
+++ b/tests/unit/preferences.rs
@@ -1,0 +1,31 @@
+use gemini_marketplace::marketplace::models::domain::{OutputFormat, SearchMode, UserPreferences};
+use gemini_marketplace::marketplace::services::preferences::PreferencesService;
+
+#[test]
+fn preferences_service_exposes_fields() {
+    let prefs = UserPreferences {
+        cache_ttl_hours: 12,
+        auto_refresh_on_launch: true,
+        search_mode: SearchMode::PreFetchFilter,
+        output_format: OutputFormat::Json,
+    };
+    let service = PreferencesService::new(prefs.clone());
+
+    assert_eq!(service.cache_ttl_hours(), 12);
+    assert!(service.auto_refresh_on_launch());
+    assert!(matches!(service.search_mode(), SearchMode::PreFetchFilter));
+    assert!(matches!(service.output_format(), OutputFormat::Json));
+
+    let mut mutable = service.clone();
+    let updated = UserPreferences {
+        cache_ttl_hours: 24,
+        auto_refresh_on_launch: false,
+        search_mode: SearchMode::LocalFilter,
+        output_format: OutputFormat::Table,
+    };
+    mutable.update(updated.clone());
+    assert_eq!(mutable.cache_ttl_hours(), 24);
+    assert!(!mutable.auto_refresh_on_launch());
+    assert!(matches!(mutable.search_mode(), SearchMode::LocalFilter));
+    assert!(matches!(mutable.output_format(), OutputFormat::Table));
+}


### PR DESCRIPTION
- stop skipping manifests that emit normalization warnings; log them instead
- update integration tests to cover warning scenarios without breaking listings
- add catalog parser unit tests to catch future regressions